### PR TITLE
Node 데이터 클래스 만들기

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/ColorRGB.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/ColorRGB.kt
@@ -1,0 +1,7 @@
+package boostcamp.and07.mindsync.data.model
+
+data class ColorRGB(
+    val red: Float,
+    val green: Float,
+    val blue: Float,
+)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/Node.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/Node.kt
@@ -1,0 +1,8 @@
+package boostcamp.and07.mindsync.data.model
+
+data class Node(
+    val path: NodePath,
+    val color: ColorRGB,
+    val description: String,
+    val nodes: List<Node>,
+)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/NodePath.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/NodePath.kt
@@ -1,0 +1,16 @@
+package boostcamp.and07.mindsync.data.model
+
+sealed class NodePath
+
+data class RectanglePath(
+    val startX: Float,
+    val endX: Float,
+    val topY: Float,
+    val bottomY: Float,
+) : NodePath()
+
+data class CirclePath(
+    val centerX: Float,
+    val centerY: Float,
+    val radius: Float,
+) : NodePath()


### PR DESCRIPTION
## 관련 이슈
close #5 
## 작업한 내용
Node 데이터 클래스 만듦
- Path, Color의 경우 androidx.graphics에 종속되는 걸 피하기 위해 직접 구현함