### PR TITLE
depth에 따른 노드 색 구현, 불필요한 코드 제거

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/SampleNode.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/SampleNode.kt
@@ -2,7 +2,6 @@ package boostcamp.and07.mindsync.data
 
 import boostcamp.and07.mindsync.data.model.CircleNode
 import boostcamp.and07.mindsync.data.model.CirclePath
-import boostcamp.and07.mindsync.data.model.ColorRGB
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.data.model.RectangleNode
 import boostcamp.and07.mindsync.data.model.RectanglePath
@@ -15,47 +14,40 @@ object SampleNode {
             Dp(100f),
             Dp(50f),
         ),
-        ColorRGB(100, 100, 100),
         "Root",
         listOf(
             RectangleNode(
                 RectanglePath(Dp(200f), Dp(100f), Dp(50f), Dp(50f)),
-                ColorRGB(200, 200, 200),
                 "Child1",
                 listOf(
                     RectangleNode(
                         RectanglePath(Dp(250f), Dp(200f), Dp(50f), Dp(50f)),
-                        ColorRGB(30, 30, 30),
                         "Child3",
                         listOf(
                             RectangleNode(
                                 RectanglePath(Dp(350f), Dp(450f), Dp(50f), Dp(50f)),
-                                ColorRGB(50, 70, 80),
                                 "Child5",
                                 listOf(),
                             ),
                             RectangleNode(
                                 RectanglePath(Dp(350f), Dp(550f), Dp(50f), Dp(50f)),
-                                ColorRGB(100, 200, 100),
                                 "Child6",
                                 listOf(),
-                            )
-                        )
+                            ),
+                        ),
                     ),
                     RectangleNode(
                         RectanglePath(Dp(250f), Dp(400f), Dp(50f), Dp(50f)),
-                        ColorRGB(10, 23, 40),
                         "Child4",
                         listOf(),
-                    )
-                )
+                    ),
+                ),
             ),
             RectangleNode(
                 RectanglePath(Dp(200f), Dp(300f), Dp(50f), Dp(50f)),
-                ColorRGB(0, 0, 0),
                 "Child2",
                 listOf(),
-            )
-        )
+            ),
+        ),
     )
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/ColorRGB.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/ColorRGB.kt
@@ -1,7 +1,0 @@
-package boostcamp.and07.mindsync.data.model
-
-data class ColorRGB(
-    val red: Int,
-    val green: Int,
-    val blue: Int,
-)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/Node.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/Node.kt
@@ -2,21 +2,18 @@ package boostcamp.and07.mindsync.data.model
 
 sealed class Node(
     open val path: NodePath,
-    open val color: ColorRGB,
     open val description: String,
     open val nodes: List<Node>,
 )
 
 data class CircleNode(
     override val path: CirclePath,
-    override val color: ColorRGB,
     override val description: String,
     override val nodes: List<Node>,
-) : Node(path, color, description, nodes)
+) : Node(path, description, nodes)
 
 data class RectangleNode(
     override val path: RectanglePath,
-    override val color: ColorRGB,
     override val description: String,
     override val nodes: List<Node>,
-) : Node(path, color, description, nodes)
+) : Node(path, description, nodes)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.util.AttributeSet
-import android.util.Log
 import android.view.View
 import boostcamp.and07.mindsync.R
 import boostcamp.and07.mindsync.data.SampleNode
@@ -39,21 +38,19 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
 
     private fun traverseNode(canvas: Canvas, node: Node, depth: Int) {
         drawNode(canvas, node, depth)
-        if (node.nodes.isNotEmpty()) {
-            node.nodes.forEach { node ->
-                traverseNode(canvas, node, depth + 1)
-            }
+        node.nodes.forEach { node ->
+            traverseNode(canvas, node, depth + 1)
         }
     }
 
     private fun drawNode(canvas: Canvas, node: Node, depth: Int) {
         when (node) {
-            is CircleNode -> drawCircleNode(canvas, node, depth)
+            is CircleNode -> drawCircleNode(canvas, node)
             is RectangleNode -> drawRectangleNode(canvas, node, depth)
         }
     }
 
-    private fun drawCircleNode(canvas: Canvas, node: CircleNode, depth: Int) {
+    private fun drawCircleNode(canvas: Canvas, node: CircleNode) {
         canvas.drawCircle(
             node.path.centerX.toPx(context).toFloat(),
             node.path.centerY.toPx(context).toFloat(),

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -2,11 +2,11 @@ package boostcamp.and07.mindsync.ui.view
 
 import android.content.Context
 import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Paint
 import android.util.AttributeSet
 import android.util.Log
 import android.view.View
+import boostcamp.and07.mindsync.R
 import boostcamp.and07.mindsync.data.SampleNode
 import boostcamp.and07.mindsync.data.model.CircleNode
 import boostcamp.and07.mindsync.data.model.Node
@@ -16,9 +16,17 @@ import boostcamp.and07.mindsync.ui.util.toPx
 class NodeView constructor(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     private val head = SampleNode.head
     private val circlePaint = Paint().apply {
-        color = Color.rgb(head.color.red, head.color.green, head.color.blue)
+        color = context.getColor(R.color.sub1)
     }
     private val rectanglePaint = Paint()
+    private val nodeColors = listOf(
+        context.getColor(R.color.main2),
+        context.getColor(R.color.main4),
+        context.getColor(R.color.main1),
+        context.getColor(R.color.main3),
+        context.getColor(R.color.sub2),
+        context.getColor(R.color.sub1),
+    )
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
@@ -55,7 +63,7 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
     }
 
     private fun drawRectangleNode(canvas: Canvas, node: RectangleNode, depth: Int) {
-        rectanglePaint.color = Color.rgb(node.color.red, node.color.green, node.color.blue)
+        rectanglePaint.color = nodeColors[(depth - 1) % nodeColors.size]
         canvas.drawRect(
             node.path.leftX().toPx(context).toFloat(),
             node.path.topY().toPx(context).toFloat(),

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -15,16 +15,15 @@ import boostcamp.and07.mindsync.ui.util.toPx
 class NodeView constructor(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     private val head = SampleNode.head
     private val circlePaint = Paint().apply {
-        color = context.getColor(R.color.sub1)
+        color = context.getColor(R.color.mindmap1)
     }
     private val rectanglePaint = Paint()
     private val nodeColors = listOf(
-        context.getColor(R.color.main2),
-        context.getColor(R.color.main4),
-        context.getColor(R.color.main1),
         context.getColor(R.color.main3),
-        context.getColor(R.color.sub2),
-        context.getColor(R.color.sub1),
+        context.getColor(R.color.mindmap2),
+        context.getColor(R.color.mindmap3),
+        context.getColor(R.color.mindmap4),
+        context.getColor(R.color.mindmap5),
     )
 
     override fun onDraw(canvas: Canvas) {

--- a/AOS/app/src/main/res/values/colors.xml
+++ b/AOS/app/src/main/res/values/colors.xml
@@ -17,4 +17,11 @@
 
     <color name="sub2">#49AA95</color>
     <color name="sub1">#FB5D67</color>
+
+
+    <color name="mindmap1">#D7558A</color>
+    <color name="mindmap2">#B9BC81</color>
+    <color name="mindmap3">#7AA37D</color>
+    <color name="mindmap4">#4B877B</color>
+    <color name="mindmap5">#336770</color>
 </resources>


### PR DESCRIPTION
## 관련 이슈
close #7 
## 작업한 내용
- depth에 따른 노드 색 구현
  <img width="200" alt="스크린샷 2023-11-15 오후 5 58 10" src="https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/b1052a41-4812-4789-8e74-e8ff792f60e5"><br>
- 불필요한 코드 제거
  - Node 속성에서 colorRBB 제거
  - NodeView의 `drawCircleNode` 함수에서 쓰지 않는 매개변수인 `depth` 제거
  - forEach문을 돌기전에 isNotEmpty를 검사하는 코드 제거 (어차피 empty면 forEach문을 돌지 않고 벗어나니까)

## 리뷰 후 수정한 부분
- Before / After
<img width="200" alt="스크린샷 2023-11-15 오후 5 58 20" src="https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/4934ad31-c5e1-4d98-9feb-15aa0c2e120c">
<img width="200" alt="image" src="https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/d8232cd7-b586-481d-8dc9-4b17ae355968">

