### PR TITLE
노드 정렬 알고리즘(LayoutManager)구현, 리팩토링

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/SampleNode.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/SampleNode.kt
@@ -11,7 +11,7 @@ object SampleNode {
     val head: Node = CircleNode(
         CirclePath(
             Dp(100f),
-            Dp(100f),
+            Dp(500f),
             Dp(50f),
         ),
         "Root",

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/Node.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/Node.kt
@@ -3,17 +3,17 @@ package boostcamp.and07.mindsync.data.model
 sealed class Node(
     open val path: NodePath,
     open val description: String,
-    open val nodes: List<Node>,
+    open val nodes: List<RectangleNode>,
 )
 
 data class CircleNode(
     override val path: CirclePath,
     override val description: String,
-    override val nodes: List<Node>,
+    override val nodes: List<RectangleNode>,
 ) : Node(path, description, nodes)
 
 data class RectangleNode(
     override val path: RectanglePath,
     override val description: String,
-    override val nodes: List<Node>,
+    override val nodes: List<RectangleNode>,
 ) : Node(path, description, nodes)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/DensityUtils.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/DensityUtils.kt
@@ -128,16 +128,16 @@ data class Px(val pxVal: Float) {
     }
 }
 
-fun Dp.toPx(context: Context): Int {
+fun Dp.toPx(context: Context): Float {
     return TypedValue.applyDimension(
         TypedValue.COMPLEX_UNIT_DIP,
         dpVal,
         context.resources
             .displayMetrics,
-    ).toInt()
+    )
 }
 
-fun Px.toDp(context: Context): Int {
+fun Px.toDp(context: Context): Float {
     val scale = context.resources.displayMetrics.density
-    return (pxVal / scale).toInt()
+    return pxVal / scale
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/DensityUtils.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/DensityUtils.kt
@@ -4,46 +4,127 @@ import android.content.Context
 import android.util.TypedValue
 
 data class Dp(val dpVal: Float) {
-    operator fun plus(value: Dp): Dp {
-        return Dp(dpVal + value.dpVal)
+    operator fun plus(dpValue: Dp): Dp {
+        return Dp(dpVal + dpValue.dpVal)
     }
 
-    operator fun minus(value: Dp): Dp {
-        return Dp(dpVal - value.dpVal)
+    operator fun minus(dpValue: Dp): Dp {
+        return Dp(dpVal - dpValue.dpVal)
     }
 
-    operator fun times(value: Dp): Dp {
-        return Dp(dpVal * value.dpVal)
+    operator fun times(dpValue: Dp): Dp {
+        return Dp(dpVal * dpValue.dpVal)
     }
 
-    operator fun div(value: Dp): Dp {
-        return Dp(dpVal / value.dpVal)
+    operator fun div(dpValue: Dp): Dp {
+        return Dp(dpVal / dpValue.dpVal)
     }
 
-    operator fun rem(value: Dp): Dp {
-        return Dp(dpVal % value.dpVal)
+    operator fun rem(dpValue: Dp): Dp {
+        return Dp(dpVal % dpValue.dpVal)
     }
+
+    operator fun plus(value: Float): Dp {
+        return Dp(dpVal + value)
+    }
+
+    operator fun minus(value: Float): Dp {
+        return Dp(dpVal - value)
+    }
+
+    operator fun times(value: Float): Dp {
+        return Dp(dpVal * value)
+    }
+
+    operator fun div(value: Float): Dp {
+        return Dp(dpVal / value)
+    }
+
+    operator fun rem(value: Float): Dp {
+        return Dp(dpVal % value)
+    }
+
+    operator fun plus(value: Int): Dp {
+        return Dp(dpVal + value)
+    }
+
+    operator fun minus(value: Int): Dp {
+        return Dp(dpVal - value)
+    }
+
+    operator fun times(value: Int): Dp {
+        return Dp(dpVal * value)
+    }
+
+    operator fun div(value: Int): Dp {
+        return Dp(dpVal / value)
+    }
+
+    operator fun rem(value: Int): Dp {
+        return Dp(dpVal % value)
+    }
+
 }
 
 data class Px(val pxVal: Float) {
-    operator fun plus(value: Px): Px {
-        return Px(pxVal + value.pxVal)
+    operator fun plus(pxValue: Px): Px {
+        return Px(pxVal + pxValue.pxVal)
     }
 
-    operator fun minus(value: Px): Px {
-        return Px(pxVal - value.pxVal)
+    operator fun minus(pxValue: Px): Px {
+        return Px(pxVal - pxValue.pxVal)
     }
 
-    operator fun times(value: Px): Px {
-        return Px(pxVal * value.pxVal)
+    operator fun times(pxValue: Px): Px {
+        return Px(pxVal * pxValue.pxVal)
     }
 
-    operator fun div(value: Px): Px {
-        return Px(pxVal / value.pxVal)
+    operator fun div(pxValue: Px): Px {
+        return Px(pxVal / pxValue.pxVal)
     }
 
-    operator fun rem(value: Px): Px {
-        return Px(pxVal % value.pxVal)
+    operator fun rem(pxValue: Px): Px {
+        return Px(pxVal % pxValue.pxVal)
+    }
+
+    operator fun plus(value: Float): Px {
+        return Px(pxVal + value)
+    }
+
+    operator fun minus(value: Float): Px {
+        return Px(pxVal - value)
+    }
+
+    operator fun times(value: Float): Px {
+        return Px(pxVal * value)
+    }
+
+    operator fun div(value: Float): Px {
+        return Px(pxVal / value)
+    }
+
+    operator fun rem(value: Float): Px {
+        return Px(pxVal % value)
+    }
+
+    operator fun plus(value: Int): Px {
+        return Px(pxVal + value)
+    }
+
+    operator fun minus(value: Int): Px {
+        return Px(pxVal - value)
+    }
+
+    operator fun times(value: Int): Px {
+        return Px(pxVal * value)
+    }
+
+    operator fun div(value: Int): Px {
+        return Px(pxVal / value)
+    }
+
+    operator fun rem(value: Int): Px {
+        return Px(pxVal % value)
     }
 }
 

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/LineView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/LineView.kt
@@ -29,19 +29,19 @@ class LineView constructor(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-        arrangement()
+        arrangeNode()
         if (head.nodes.isNotEmpty()) {
             traverseLine(canvas, head, 1)
         }
     }
 
     override fun invalidate() {
-        arrangement()
+        arrangeNode()
         super.invalidate()
     }
 
-    private fun arrangement() {
-        head = rightLayoutManager.arrangement(head)
+    private fun arrangeNode() {
+        head = rightLayoutManager.arrangeNode(head)
     }
 
     private fun traverseLine(canvas: Canvas, node: Node, depth: Int) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/LineView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/LineView.kt
@@ -20,7 +20,7 @@ class LineView constructor(
     private val paint = Paint().apply {
         color = Color.BLACK
         style = Paint.Style.STROKE
-        strokeWidth = Dp(5f).toPx(context).toFloat()
+        strokeWidth = Dp(5f).toPx(context)
         isAntiAlias = true
     }
     private val path = Path()
@@ -44,12 +44,12 @@ class LineView constructor(
         val path = path.apply {
             reset()
             moveTo(
-                fromNode.path.centerX.toPx(context).toFloat(),
-                fromNode.path.centerY.toPx(context).toFloat(),
+                fromNode.path.centerX.toPx(context),
+                fromNode.path.centerY.toPx(context),
             )
             lineTo(
-                toNode.path.centerX.toPx(context).toFloat(),
-                toNode.path.centerY.toPx(context).toFloat(),
+                toNode.path.centerX.toPx(context),
+                toNode.path.centerY.toPx(context),
             )
         }
         canvas.drawPath(path, paint)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/LineView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/LineView.kt
@@ -6,16 +6,16 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
 import android.util.AttributeSet
-import android.util.Log
 import android.view.View
 import boostcamp.and07.mindsync.data.SampleNode
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.ui.util.Dp
 import boostcamp.and07.mindsync.ui.util.toPx
+import boostcamp.and07.mindsync.ui.view.layout.MindmapRightLayoutManager
 
 class LineView constructor(
     context: Context,
-    attrs: AttributeSet? = null
+    attrs: AttributeSet? = null,
 ) : View(context, attrs) {
     private val paint = Paint().apply {
         color = Color.BLACK
@@ -24,13 +24,24 @@ class LineView constructor(
         isAntiAlias = true
     }
     private val path = Path()
-    private val head = SampleNode.head
+    private var head = SampleNode.head
+    private val rightLayoutManager = MindmapRightLayoutManager()
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        arrangement()
         if (head.nodes.isNotEmpty()) {
             traverseLine(canvas, head, 1)
         }
+    }
+
+    override fun invalidate() {
+        arrangement()
+        super.invalidate()
+    }
+
+    private fun arrangement() {
+        head = rightLayoutManager.arrangement(head)
     }
 
     private fun traverseLine(canvas: Canvas, node: Node, depth: Int) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -51,9 +51,9 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
 
     private fun drawCircleNode(canvas: Canvas, node: CircleNode) {
         canvas.drawCircle(
-            node.path.centerX.toPx(context).toFloat(),
-            node.path.centerY.toPx(context).toFloat(),
-            node.path.radius.toPx(context).toFloat(),
+            node.path.centerX.toPx(context),
+            node.path.centerY.toPx(context),
+            node.path.radius.toPx(context),
             circlePaint,
         )
     }
@@ -61,10 +61,10 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
     private fun drawRectangleNode(canvas: Canvas, node: RectangleNode, depth: Int) {
         rectanglePaint.color = nodeColors[(depth - 1) % nodeColors.size]
         canvas.drawRect(
-            node.path.leftX().toPx(context).toFloat(),
-            node.path.topY().toPx(context).toFloat(),
-            node.path.rightX().toPx(context).toFloat(),
-            node.path.bottomY().toPx(context).toFloat(),
+            node.path.leftX().toPx(context),
+            node.path.topY().toPx(context),
+            node.path.rightX().toPx(context),
+            node.path.bottomY().toPx(context),
             rectanglePaint,
         )
     }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -11,9 +11,10 @@ import boostcamp.and07.mindsync.data.model.CircleNode
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.data.model.RectangleNode
 import boostcamp.and07.mindsync.ui.util.toPx
+import boostcamp.and07.mindsync.ui.view.layout.MindmapRightLayoutManager
 
 class NodeView constructor(context: Context, attrs: AttributeSet?) : View(context, attrs) {
-    private val head = SampleNode.head
+    private var head = SampleNode.head
     private val circlePaint = Paint().apply {
         color = context.getColor(R.color.mindmap1)
     }
@@ -25,10 +26,21 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
         context.getColor(R.color.mindmap4),
         context.getColor(R.color.mindmap5),
     )
+    private val rightLayoutManager = MindmapRightLayoutManager()
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        arrangement()
         traverseHead(canvas)
+    }
+
+    override fun invalidate() {
+        arrangement()
+        super.invalidate()
+    }
+
+    private fun arrangement() {
+        head = rightLayoutManager.arrangement(head)
     }
 
     private fun traverseHead(canvas: Canvas) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -30,17 +30,17 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-        arrangement()
+        arrangeNode()
         traverseHead(canvas)
     }
 
     override fun invalidate() {
-        arrangement()
+        arrangeNode()
         super.invalidate()
     }
 
-    private fun arrangement() {
-        head = rightLayoutManager.arrangement(head)
+    private fun arrangeNode() {
+        head = rightLayoutManager.arrangeNode(head)
     }
 
     private fun traverseHead(canvas: Canvas) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindmapLayoutManager.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindmapLayoutManager.kt
@@ -1,0 +1,69 @@
+package boostcamp.and07.mindsync.ui.view.layout
+
+import boostcamp.and07.mindsync.data.model.CircleNode
+import boostcamp.and07.mindsync.data.model.Node
+import boostcamp.and07.mindsync.data.model.RectangleNode
+import boostcamp.and07.mindsync.ui.util.Dp
+
+class MindmapRightLayoutManager {
+    private val horizontalSpacing = Dp(50f)
+    private val verticalSpacing = Dp(50f)
+
+    fun arrangement(node: Node): Node {
+        val childHeightSum = measureChildHeight(node)
+        val newNodes = mutableListOf<RectangleNode>()
+
+        val nodeWidth = when (node) {
+            is RectangleNode -> node.path.width
+            is CircleNode -> node.path.radius
+        }
+
+        val criteriaX = node.path.centerX + nodeWidth + horizontalSpacing
+        var startX: Dp
+        var startY = node.path.centerY - (childHeightSum / 2)
+
+        node.nodes.forEach { childNode ->
+            startX = criteriaX + (childNode.path.width / 2)
+
+            val childHeight = measureChildHeight(childNode)
+            val newCenterY = startY + (childHeight / 2)
+            val newPath = childNode.path.copy(centerX = startX, centerY = newCenterY)
+
+            newNodes.add(
+                childNode.copy(path = newPath),
+            )
+
+            startY += childHeight + verticalSpacing
+        }
+
+        newNodes.forEachIndexed { index, childNode ->
+            newNodes[index] = arrangement(childNode) as RectangleNode
+        }
+
+        val newNode = when (node) {
+            is RectangleNode -> node.copy(nodes = newNodes)
+            is CircleNode -> node.copy(nodes = newNodes)
+        }
+
+        return newNode
+    }
+
+    private fun measureChildHeight(node: Node): Dp {
+        var heightSum = Dp(0f)
+
+        if (node.nodes.isNotEmpty()) {
+            node.nodes.forEach { childNode ->
+                heightSum += measureChildHeight(childNode)
+            }
+            heightSum += verticalSpacing * (node.nodes.size - 1)
+        } else {
+            heightSum = when (node) {
+                is CircleNode -> node.path.radius
+                is RectangleNode -> node.path.height
+            }
+        }
+
+        return heightSum
+    }
+
+}

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindmapLayoutManager.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindmapLayoutManager.kt
@@ -65,5 +65,4 @@ class MindmapRightLayoutManager {
 
         return heightSum
     }
-
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindmapLayoutManager.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindmapLayoutManager.kt
@@ -9,7 +9,7 @@ class MindmapRightLayoutManager {
     private val horizontalSpacing = Dp(50f)
     private val verticalSpacing = Dp(50f)
 
-    fun arrangement(node: Node): Node {
+    fun arrangeNode(node: Node): Node {
         val childHeightSum = measureChildHeight(node)
         val newNodes = mutableListOf<RectangleNode>()
 
@@ -37,7 +37,7 @@ class MindmapRightLayoutManager {
         }
 
         newNodes.forEachIndexed { index, childNode ->
-            newNodes[index] = arrangement(childNode) as RectangleNode
+            newNodes[index] = arrangeNode(childNode) as RectangleNode
         }
 
         val newNode = when (node) {


### PR DESCRIPTION
## 관련 이슈
- #6 

## 작업한 내용
1. **Head 의 노드 정보가 주어졌을 때, Head를 기준으로 나머지의 위치를 재정렬 하는 코드 작성**
    - Before : x, y 좌표를 직접 정해주지 않으면 자유분방하게 배치됨
    <img width="150" alt="스크린샷 2023-11-18 오후 9 32 24" src="https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/d496c3bd-cbfe-432d-baa6-fd28b43ef65b"><br>
    
    - After : arrangement 함수만 호출해주면 자동으로 정렬됨  
    <img width="150" alt="스크린샷 2023-11-18 오후 9 32 44" src="https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/b91a5c0c-021c-4b99-903d-86d7a90c45bb"><br>

2. **리팩토링**
    - Node 클래스의 nodes 타입을 List<Node>에서 List<RectangleNode>로 변경함. 자식 노드는 무조건 RectangleNode라서 변경.
    - Dp, Px 클래스에서 operator 추가 구현 (float, int로도 연산 가능하도록 함)
    - toPx, toDp의 함수의 반환값이 기존에는 Int형이었는데, 매번 float로 바꾸는 일이 많아서 float를 반환하도록 변경
- 