### PR TITLE
마인드맵 화면 구성

### DIFF
--- a/AOS/app/src/main/AndroidManifest.xml
+++ b/AOS/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@style/Theme.MindSync"
         tools:targetApi="31">
         <activity
-            android:name="MainActivity"
+            android:name=".ui.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/MainActivity.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/MainActivity.kt
@@ -1,7 +1,8 @@
-package boostcamp.and07.mindsync
+package boostcamp.and07.mindsync.ui
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import boostcamp.and07.mindsync.R
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindmapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindmapFragment.kt
@@ -1,0 +1,10 @@
+package boostcamp.and07.mindsync.ui.mindmap
+
+import boostcamp.and07.mindsync.R
+import boostcamp.and07.mindsync.databinding.FragmentMindmapBinding
+import boostcamp.and07.mindsync.ui.base.BaseFragment
+
+class MindmapFragment : BaseFragment<FragmentMindmapBinding>(R.layout.fragment_mindmap) {
+    override fun initView() {
+    }
+}

--- a/AOS/app/src/main/res/drawable/ic_remove.xml
+++ b/AOS/app/src/main/res/drawable/ic_remove.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="25dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM17,13L7,13v-2h10v2z" />
+</vector>

--- a/AOS/app/src/main/res/layout/activity_main.xml
+++ b/AOS/app/src/main/res/layout/activity_main.xml
@@ -6,25 +6,11 @@
     android:layout_height="match_parent"
     tools:context=".ui.MainActivity">
 
-    <boostcamp.and07.mindsync.ui.view.LineView
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fcv_main_nav_host"
+        android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
-    <boostcamp.and07.mindsync.ui.view.NodeView
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_height="match_parent"
+        app:navGraph="@navigation/nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AOS/app/src/main/res/layout/activity_main.xml
+++ b/AOS/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".ui.MainActivity">
 
     <boostcamp.and07.mindsync.ui.view.LineView
         android:layout_width="match_parent"

--- a/AOS/app/src/main/res/layout/fragment_mindmap.xml
+++ b/AOS/app/src/main/res/layout/fragment_mindmap.xml
@@ -1,20 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
     </data>
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.mindmap.MindmapFragment">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:text="Hello" />
+        <LinearLayout
+            android:id="@+id/ll_mindmap_bottom_bar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@color/gray1"
+            android:orientation="horizontal"
+            android:paddingHorizontal="30dp"
+            android:paddingVertical="15dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
 
-    </FrameLayout>
+            <ImageButton
+                android:id="@+id/imgbtn_mindmap_add"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_add" />
+
+            <ImageButton
+                android:id="@+id/imgbtn_mindmap_remove"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_remove" />
+
+            <ImageButton
+                android:id="@+id/imgbtn_mindmap_edit"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_outlined_drawing" />
+
+            <ImageButton
+                android:id="@+id/imgbtn_mindmap_back"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:layout_weight="1"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_undo" />
+
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/AOS/app/src/main/res/layout/fragment_mindmap.xml
+++ b/AOS/app/src/main/res/layout/fragment_mindmap.xml
@@ -15,7 +15,6 @@
         <boostcamp.and07.mindsync.ui.view.LineView
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@id/ll_mindmap_bottom_bar"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -23,56 +22,77 @@
         <boostcamp.and07.mindsync.ui.view.NodeView
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@id/ll_mindmap_bottom_bar"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <LinearLayout
-            android:id="@+id/ll_mindmap_bottom_bar"
+        <androidx.constraintlayout.widget.Group
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:constraint_referenced_ids="imgbtn_mindmap_add,imgbtn_mindmap_back,imgbtn_mindmap_remove,imgbtn_mindmap_edit,view_mindmap_side_bar"
+            app:layout_constraintBottom_toBottomOf="@id/view_mindmap_side_bar"
+            app:layout_constraintEnd_toEndOf="@id/view_mindmap_side_bar"
+            app:layout_constraintStart_toStartOf="@id/view_mindmap_side_bar"
+            app:layout_constraintTop_toTopOf="@id/view_mindmap_side_bar" />
+
+        <View
+            android:id="@+id/view_mindmap_side_bar"
+            android:layout_width="0dp"
+            android:layout_height="60dp"
             android:background="@color/gray2"
-            android:orientation="horizontal"
-            android:paddingHorizontal="30dp"
-            android:paddingVertical="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintStart_toStartOf="parent" />
 
-            <ImageButton
-                android:id="@+id/imgbtn_mindmap_add"
-                android:layout_width="25dp"
-                android:layout_height="25dp"
-                android:layout_weight="1"
-                android:background="@android:color/transparent"
-                android:src="@drawable/ic_add" />
+        <ImageButton
+            android:id="@+id/imgbtn_mindmap_add"
+            android:layout_width="25dp"
+            android:layout_height="25dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_add"
+            app:layout_constraintBottom_toBottomOf="@id/view_mindmap_side_bar"
+            app:layout_constraintEnd_toStartOf="@id/imgbtn_mindmap_remove"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toStartOf="@id/view_mindmap_side_bar"
+            app:layout_constraintTop_toTopOf="@id/view_mindmap_side_bar" />
 
-            <ImageButton
-                android:id="@+id/imgbtn_mindmap_remove"
-                android:layout_width="25dp"
-                android:layout_height="25dp"
-                android:layout_weight="1"
-                android:background="@android:color/transparent"
-                android:src="@drawable/ic_remove" />
+        <ImageButton
+            android:id="@+id/imgbtn_mindmap_remove"
+            android:layout_width="25dp"
+            android:layout_height="25dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_remove"
+            app:layout_constraintBottom_toBottomOf="@id/view_mindmap_side_bar"
+            app:layout_constraintEnd_toStartOf="@id/imgbtn_mindmap_edit"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toEndOf="@id/imgbtn_mindmap_add"
+            app:layout_constraintTop_toTopOf="@id/view_mindmap_side_bar" />
 
-            <ImageButton
-                android:id="@+id/imgbtn_mindmap_edit"
-                android:layout_width="25dp"
-                android:layout_height="25dp"
-                android:layout_weight="1"
-                android:background="@android:color/transparent"
-                android:src="@drawable/ic_outlined_drawing" />
+        <ImageButton
+            android:id="@+id/imgbtn_mindmap_edit"
+            android:layout_width="25dp"
+            android:layout_height="25dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_outlined_drawing"
+            app:layout_constraintBottom_toBottomOf="@id/view_mindmap_side_bar"
+            app:layout_constraintEnd_toStartOf="@id/imgbtn_mindmap_back"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toEndOf="@id/imgbtn_mindmap_remove"
+            app:layout_constraintTop_toTopOf="@id/view_mindmap_side_bar" />
 
-            <ImageButton
-                android:id="@+id/imgbtn_mindmap_back"
-                android:layout_width="25dp"
-                android:layout_height="25dp"
-                android:layout_weight="1"
-                android:background="@android:color/transparent"
-                android:src="@drawable/ic_undo" />
+        <ImageButton
+            android:id="@+id/imgbtn_mindmap_back"
+            android:layout_width="25dp"
+            android:layout_height="25dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_undo"
+            app:layout_constraintBottom_toBottomOf="@id/view_mindmap_side_bar"
+            app:layout_constraintEnd_toEndOf="@id/view_mindmap_side_bar"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toEndOf="@id/imgbtn_mindmap_edit"
+            app:layout_constraintTop_toTopOf="@id/view_mindmap_side_bar" />
 
-        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/AOS/app/src/main/res/layout/fragment_mindmap.xml
+++ b/AOS/app/src/main/res/layout/fragment_mindmap.xml
@@ -32,10 +32,10 @@
             android:id="@+id/ll_mindmap_bottom_bar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:background="@color/gray1"
+            android:background="@color/gray2"
             android:orientation="horizontal"
             android:paddingHorizontal="30dp"
-            android:paddingVertical="15dp"
+            android:paddingVertical="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">

--- a/AOS/app/src/main/res/layout/fragment_mindmap.xml
+++ b/AOS/app/src/main/res/layout/fragment_mindmap.xml
@@ -12,6 +12,22 @@
         android:layout_height="match_parent"
         tools:context=".ui.mindmap.MindmapFragment">
 
+        <boostcamp.and07.mindsync.ui.view.LineView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/ll_mindmap_bottom_bar"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <boostcamp.and07.mindsync.ui.view.NodeView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/ll_mindmap_bottom_bar"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <LinearLayout
             android:id="@+id/ll_mindmap_bottom_bar"
             android:layout_width="0dp"

--- a/AOS/app/src/main/res/layout/fragment_mindmap.xml
+++ b/AOS/app/src/main/res/layout/fragment_mindmap.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.mindmap.MindmapFragment">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="Hello" />
+
+    </FrameLayout>
+</layout>

--- a/AOS/app/src/main/res/navigation/nav_graph.xml
+++ b/AOS/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/mindmapFragment">
+
+    <fragment
+        android:id="@+id/mindmapFragment"
+        android:name="boostcamp.and07.mindsync.ui.mindmap.MindmapFragment"
+        android:label="MindmapFragment" />
+</navigation>


### PR DESCRIPTION
## 관련 이슈
- #51 
## 작업한 내용
- 보드 화면 xml
  -  바텀 네비게이션으로 하려 했으나, 바텀 네비게이션의 의미가 눌렀을 때 다른 화면으로 전환 되는 의미가 강한것 같아 단순 레이아웃과 버튼으로 구성함.
- 보드 화면 Fragment 설정
![image](https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/66833070-cf58-4910-9a00-98bf3af66b3c)


