### PR TITLE
AOS-ktlint 적용 브랜치 변경

### DIFF
--- a/.github/workflows/AOS-ktlint.yml
+++ b/.github/workflows/AOS-ktlint.yml
@@ -2,8 +2,8 @@ name: AOS-ktlint
 on:
   pull_request:
     branches:
-      - main
       - AOS-develop
+      - AOS-*/**
   push:
     paths:
       - '**.kt'


### PR DESCRIPTION
## 작업한 내용
- 기존엔 AOS-develop 브랜치에서만 ktlint 검사를 진행했는데, AOS-가 붙는 브랜치면 모두 검사하도록 변경
- 지금은 존재하지 않는 main branch에 관한 내용은 지움