### PR TITLE
커스텀뷰, MindmapContainer 리팩토링

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -97,4 +97,8 @@ class MindMapViewModel : ViewModel() {
             is CircleNode -> node.copy(nodes = newNodes)
         }
     }
+
+    fun updateHead(newHead: Node) {
+        _head.value = newHead
+    }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/LineView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/LineView.kt
@@ -10,11 +10,11 @@ import android.view.View
 import boostcamp.and07.mindsync.data.model.CircleNode
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.data.model.RectangleNode
-import boostcamp.and07.mindsync.ui.mindmap.MindMapViewModel
 import boostcamp.and07.mindsync.ui.util.Dp
 import boostcamp.and07.mindsync.ui.util.toPx
 
 class LineView constructor(
+    val mindmapContainer: MindmapContainer,
     context: Context,
     attrs: AttributeSet? = null,
 ) : View(context, attrs) {
@@ -25,27 +25,12 @@ class LineView constructor(
         isAntiAlias = true
     }
     private val path = Path()
-
-    // private var head = SampleNode.head
-
-    lateinit var head: Node
-    private lateinit var mindMapViewModel: MindMapViewModel
-
+    private lateinit var head: Node
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         if (head.nodes.isNotEmpty()) {
             traverseLine(canvas, head, 0)
         }
-    }
-
-    fun updateWithNewHead(newHead: Node) {
-        head = newHead
-        invalidate()
-    }
-
-    fun setViewModel(viewModel: MindMapViewModel) {
-        this.mindMapViewModel = viewModel
-        head = viewModel.head.value
     }
 
     fun updateHead(headNode: Node) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/MindmapContainer.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/MindmapContainer.kt
@@ -1,23 +1,30 @@
 package boostcamp.and07.mindsync.ui.view
 
 import boostcamp.and07.mindsync.data.model.Node
-import boostcamp.and07.mindsync.ui.mindmap.MindMapViewModel
+import boostcamp.and07.mindsync.ui.view.listener.NodeClickListener
+import boostcamp.and07.mindsync.ui.view.listener.NodeUpdateListener
 
 class MindmapContainer {
 
-    lateinit var mindMapViewModel: MindMapViewModel
     lateinit var head: Node
-
-    var nodeView: NodeView? = null
-    var lineView: LineView? = null
-
-    fun setViewModel(mindMapViewModel: MindMapViewModel) {
-        this.mindMapViewModel = mindMapViewModel
-        head = mindMapViewModel.head.value
+    var selectNode: Node? = null
+    private var nodeClickListener: NodeClickListener? = null
+    private var nodeUpdateListener: NodeUpdateListener? = null
+    fun setNodeClickListener(clickListener: NodeClickListener) {
+        this.nodeClickListener = clickListener
     }
 
-    fun updateHead(newHead: Node) {
-        head = newHead
-        lineView?.updateWithNewHead(newHead)
+    fun setNodeUpdateListener(updateListener: NodeUpdateListener) {
+        this.nodeUpdateListener = updateListener
+    }
+
+    fun updateHead(head: Node) {
+        this.head = head
+        nodeUpdateListener?.updateHead(head)
+    }
+
+    fun setSelectedNode(selectedNode: Node?) {
+        this.selectNode = selectedNode
+        nodeClickListener?.clickNode(selectedNode)
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -14,7 +14,6 @@ import boostcamp.and07.mindsync.R
 import boostcamp.and07.mindsync.data.model.CircleNode
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.data.model.RectangleNode
-import boostcamp.and07.mindsync.ui.mindmap.MindMapViewModel
 import boostcamp.and07.mindsync.ui.util.Dp
 import boostcamp.and07.mindsync.ui.util.Px
 import boostcamp.and07.mindsync.ui.util.toDp
@@ -22,8 +21,12 @@ import boostcamp.and07.mindsync.ui.util.toPx
 import boostcamp.and07.mindsync.ui.view.layout.MindmapRightLayoutManager
 import java.lang.Float.max
 
-class NodeView constructor(context: Context, attrs: AttributeSet?) : View(context, attrs) {
-    private lateinit var head: Node
+class NodeView constructor(
+    val mindmapContainer: MindmapContainer,
+    context: Context,
+    attrs: AttributeSet?,
+) : View(context, attrs) {
+    lateinit var head: Node
     private val circlePaint = Paint().apply {
         color = context.getColor(R.color.mindmap1)
     }
@@ -51,22 +54,20 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
     private val rightLayoutManager = MindmapRightLayoutManager()
     private val lineHeight = Dp(15f)
     private val padding = Dp(20f)
-    var mindmapContainer: MindmapContainer? = null
-    private var mindMapViewModel = mindmapContainer?.mindMapViewModel
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         traverseTextHead()
         arrangeNode()
         traverseDrawHead(canvas)
-        mindMapViewModel?.selectedNode?.value?.let { selectNode ->
-            makeStrokeNode(canvas, selectNode)
+        mindmapContainer.selectNode?.let { selectedNode ->
+            makeStrokeNode(canvas, selectedNode)
         }
     }
 
     private fun arrangeNode() {
         head = rightLayoutManager.arrangeNode(head)
-        mindmapContainer?.updateHead(head)
+        mindmapContainer.updateHead(head)
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
@@ -76,11 +77,6 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
             }
         }
         return super.onTouchEvent(event)
-    }
-
-    fun setViewModel(viewModel: MindMapViewModel) {
-        this.mindMapViewModel = viewModel
-        head = viewModel.head.value
     }
 
     fun updateHead(headNode: Node) {
@@ -93,9 +89,9 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
     }
 
     private fun traverseDrawNode(canvas: Canvas, node: Node, depth: Int) {
-        mindMapViewModel?.selectedNode?.value.let { selectedNode ->
-            if (selectedNode?.id == node.id) {
-                mindMapViewModel?.setSelectedNode(node)
+        mindmapContainer.selectNode?.let { selectedNode ->
+            if (selectedNode.id == node.id) {
+                mindmapContainer.setSelectedNode(node)
             }
         }
         drawNode(canvas, node, depth)
@@ -106,7 +102,7 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
 
     private fun traverseTextHead() {
         head = traverseTextNode(head)
-        mindmapContainer?.updateHead(head)
+        mindmapContainer.updateHead(head)
     }
 
     private fun traverseTextNode(node: Node): Node {
@@ -158,9 +154,11 @@ class NodeView constructor(context: Context, attrs: AttributeSet?) : View(contex
         val rangeResult = traverseRangeNode(head, x, y, 0)
 
         rangeResult?.let {
-            mindMapViewModel?.setSelectedNode(it.first)
+            mindmapContainer.setSelectedNode(it.first)
+            // mindMapViewModel?.setSelectedNode(it.first)
         } ?: run {
-            mindMapViewModel?.setSelectedNode(null)
+            mindmapContainer.setSelectedNode(null)
+            // mindMapViewModel?.setSelectedNode(null)
         }
         invalidate()
     }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
@@ -5,7 +5,6 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import androidx.constraintlayout.widget.ConstraintLayout
-import boostcamp.and07.mindsync.ui.mindmap.MindMapViewModel
 import boostcamp.and07.mindsync.ui.view.model.LayoutMode
 import java.lang.Float.max
 import java.lang.Float.min
@@ -33,19 +32,12 @@ class ZoomLayout(context: Context, attrs: AttributeSet? = null) : ConstraintLayo
     lateinit var nodeView: NodeView
     lateinit var lineView: LineView
     lateinit var mindmapContainer: MindmapContainer
-    lateinit var mindMapViewModel: MindMapViewModel
 
     fun initializeZoomLayout() {
-        mindMapViewModel = mindmapContainer.mindMapViewModel
-        nodeView = NodeView(context, attrs = null)
-        nodeView.setViewModel(mindMapViewModel)
-        lineView = LineView(context, attrs = null)
-        lineView.setViewModel(mindMapViewModel)
-        mindmapContainer.nodeView = nodeView
-        mindmapContainer.lineView = lineView
-        nodeView.mindmapContainer = mindmapContainer
-        addView(nodeView)
+        nodeView = NodeView(mindmapContainer, context, attrs = null)
+        lineView = LineView(mindmapContainer, context, attrs = null)
         addView(lineView)
+        addView(nodeView)
         applyScaleAndTranslation()
     }
 

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/listener/NodeClickListener.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/listener/NodeClickListener.kt
@@ -1,0 +1,9 @@
+package boostcamp.and07.mindsync.ui.view.listener
+
+import boostcamp.and07.mindsync.data.model.Node
+
+interface NodeClickListener {
+    fun clickNode(node: Node?)
+}
+
+

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/listener/NodeUpdateListener.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/listener/NodeUpdateListener.kt
@@ -1,0 +1,7 @@
+package boostcamp.and07.mindsync.ui.view.listener
+
+import boostcamp.and07.mindsync.data.model.Node
+
+interface NodeUpdateListener {
+    fun updateHead(head: Node)
+}


### PR DESCRIPTION
## 관련 이슈
- #77 
## 작업한 내용
-  customView <-> ViewModel 주입 제거
-  mindmapContainer <-> ViewModel 주입 제거
-   customView <-> mindmapContainer 생성자 주입
-  NodeListener 구현
   - click
   - update
## To Reviewers
기존 코드는 커스텀뷰와 MindmapContainer들이 viewModel과의 의존성이 높았습니다.
따라서 의존성을 줄이고자 각 custom View에서 MindmapContainer를 주입받고, 이벤트 처리를 MindmapContainer와 View(Fragment), ViewModel이 주고받고, 각 custom View는 mindmapContainer를 주입받는 형태로 바꿔봤는데 맞는 방법인지는 모르겠네요..
custom View가 viewModel을 들고있으면 안된다는 말도 없는거같고!! 
더 좋은 방향으로 개선하고 싶긴하네요 ㅠ 좋은 의견 있을까요..?