### PR TITLE
화면 범위를 초과하는 노드 잘림 현상 수정

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -9,9 +9,10 @@ import boostcamp.and07.mindsync.data.model.RectangleNode
 import boostcamp.and07.mindsync.ui.util.Dp
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 
 class MindMapViewModel : ViewModel() {
-    private var _head = MutableStateFlow<Node>(
+    private val _head = MutableStateFlow<Node>(
         CircleNode(
             id = IdGenerator.makeRandomNodeId(),
             path = CirclePath(
@@ -100,5 +101,13 @@ class MindMapViewModel : ViewModel() {
 
     fun updateHead(newHead: Node) {
         _head.value = newHead
+    }
+
+    fun updateHead(windowHeight: Dp) {
+        _head.update { root ->
+            (root as CircleNode).copy(
+                path = root.path.copy(centerY = windowHeight),
+            )
+        }
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindmapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindmapFragment.kt
@@ -11,6 +11,9 @@ import boostcamp.and07.mindsync.databinding.FragmentMindmapBinding
 import boostcamp.and07.mindsync.ui.base.BaseFragment
 import boostcamp.and07.mindsync.ui.dialog.EditDescriptionDialog
 import boostcamp.and07.mindsync.ui.dialog.EditDialogInterface
+import boostcamp.and07.mindsync.ui.util.Dp
+import boostcamp.and07.mindsync.ui.util.Px
+import boostcamp.and07.mindsync.ui.util.toDp
 import boostcamp.and07.mindsync.ui.view.MindmapContainer
 import boostcamp.and07.mindsync.ui.view.listener.NodeClickListener
 import boostcamp.and07.mindsync.ui.view.listener.NodeUpdateListener
@@ -25,9 +28,16 @@ class MindmapFragment :
     private val mindMapViewModel: MindMapViewModel by viewModels()
     private val mindmapContainer = MindmapContainer()
     override fun initView() {
+        setupRootNode()
         setBinding()
         collectHead()
         collectSelectedNode()
+    }
+
+    private fun setupRootNode() {
+        val displayMetrics = requireActivity().resources.displayMetrics
+        val screenHeight = Dp(Px(displayMetrics.heightPixels.toFloat()).toDp(requireContext()))
+        mindMapViewModel.updateHead(screenHeight / 2)
     }
 
     private fun setBinding() {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
@@ -12,12 +12,16 @@ import java.lang.Float.min
 
 class ZoomLayout(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
     private var scaleFactor = DEFAULT_ZOOM
+    private var focusX = 0f
+    private var focusY = 0f
     private val scaleGestureDetector = ScaleGestureDetector(
         context,
         object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
             override fun onScale(detector: ScaleGestureDetector): Boolean {
                 scaleFactor *= detector.scaleFactor
                 scaleFactor = max(MIN_ZOOM, min(scaleFactor, MAX_ZOOM))
+                focusX = detector.focusX
+                focusY = detector.focusY
                 requestLayout()
                 applyScaleAndTranslation()
                 return true
@@ -122,6 +126,8 @@ class ZoomLayout(context: Context, attrs: AttributeSet? = null) : ConstraintLayo
             with(getChildAt(index)) {
                 scaleX = scaleFactor
                 scaleY = scaleFactor
+                pivotX = focusX
+                pivotY = focusY
                 translationX = dx
                 translationY = dy
             }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
@@ -2,7 +2,6 @@ package boostcamp.and07.mindsync.ui.view
 
 import android.content.Context
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import androidx.constraintlayout.widget.ConstraintLayout

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
-import androidx.constraintlayout.widget.ConstraintLayout
+import android.widget.FrameLayout
 import boostcamp.and07.mindsync.ui.view.model.LayoutMode
 import java.lang.Float.max
 import java.lang.Float.min
 
-class ZoomLayout(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
+class ZoomLayout(context: Context, attrs: AttributeSet? = null) : FrameLayout(context, attrs) {
     private var scaleFactor = DEFAULT_ZOOM
     private var focusX = 0f
     private var focusY = 0f

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
@@ -136,7 +136,7 @@ class ZoomLayout(context: Context, attrs: AttributeSet? = null) : ConstraintLayo
 
     companion object {
         private const val DEFAULT_ZOOM = 1f
-        private const val MIN_ZOOM = 0.5f
+        private const val MIN_ZOOM = 0.2f
         private const val MAX_ZOOM = 5f
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/ZoomLayout.kt
@@ -2,6 +2,7 @@ package boostcamp.and07.mindsync.ui.view
 
 import android.content.Context
 import android.util.AttributeSet
+import android.util.Log
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -17,6 +18,7 @@ class ZoomLayout(context: Context, attrs: AttributeSet? = null) : ConstraintLayo
             override fun onScale(detector: ScaleGestureDetector): Boolean {
                 scaleFactor *= detector.scaleFactor
                 scaleFactor = max(MIN_ZOOM, min(scaleFactor, MAX_ZOOM))
+                requestLayout()
                 applyScaleAndTranslation()
                 return true
             }
@@ -39,6 +41,35 @@ class ZoomLayout(context: Context, attrs: AttributeSet? = null) : ConstraintLayo
         addView(lineView)
         addView(nodeView)
         applyScaleAndTranslation()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        var width = 0
+        var height = 0
+        for (index in 0 until childCount) {
+            val child = getChildAt(index)
+            measureChild(child, widthMeasureSpec, heightMeasureSpec)
+            width = maxOf(width, child.measuredWidth)
+            height = maxOf(height, child.measuredHeight)
+        }
+        setMeasuredDimension(
+            resolveSize(width, widthMeasureSpec),
+            resolveSize(height, heightMeasureSpec),
+        )
+    }
+
+    override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+        val childCount = childCount
+        for (index in 0 until childCount) {
+            val child = getChildAt(index)
+            val childLeft =
+                (paddingLeft + (child.layoutParams as MarginLayoutParams).leftMargin)
+            val childTop =
+                (paddingTop + (child.layoutParams as MarginLayoutParams).topMargin)
+            val childRight = Int.MAX_VALUE
+            val childBottom = Int.MAX_VALUE
+            child.layout(childLeft, childTop, childRight, childBottom)
+        }
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
@@ -100,6 +131,6 @@ class ZoomLayout(context: Context, attrs: AttributeSet? = null) : ConstraintLayo
     companion object {
         private const val DEFAULT_ZOOM = 1f
         private const val MIN_ZOOM = 0.5f
-        private const val MAX_ZOOM = 10f
+        private const val MAX_ZOOM = 5f
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindmapLayoutManager.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindmapLayoutManager.kt
@@ -1,6 +1,7 @@
 package boostcamp.and07.mindsync.ui.view.layout
 
 import boostcamp.and07.mindsync.data.model.CircleNode
+import boostcamp.and07.mindsync.data.model.CirclePath
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.data.model.RectangleNode
 import boostcamp.and07.mindsync.ui.util.Dp
@@ -39,16 +40,26 @@ class MindmapRightLayoutManager {
         newNodes.forEachIndexed { index, childNode ->
             newNodes[index] = arrangeNode(childNode) as RectangleNode
         }
-
         val newNode = when (node) {
             is RectangleNode -> node.copy(nodes = newNodes)
-            is CircleNode -> node.copy(nodes = newNodes)
+            is CircleNode -> {
+                val newCenterY =
+                    if (node.path.centerY.dpVal >= (childHeightSum / 2).dpVal) node.path.centerY else childHeightSum / 2
+                node.copy(
+                    path = CirclePath(
+                        centerX = node.path.centerX,
+                        centerY = newCenterY,
+                        radius = node.path.radius,
+                    ),
+                    nodes = newNodes,
+                )
+            }
         }
 
         return newNode
     }
 
-    private fun measureChildHeight(node: Node): Dp {
+    fun measureChildHeight(node: Node): Dp {
         var heightSum = Dp(0f)
 
         if (node.nodes.isNotEmpty()) {


### PR DESCRIPTION
## 관련 이슈
- close #65 

## 작업한 내용
- 화면 크기에 맞게 마인드맵 크기 조절
- 뷰의 포커스 지점에 맞게 확대/축소
- 최소 줌 0.2f로 수정

### 노드 잘리는 현상
[노드잘림.webm](https://github.com/boostcampwm2023/and07-MindSync/assets/39490416/1bf9d92c-97d5-4e32-b5c2-c367579a5f93)

### 화면 크기에 맞게 마인드맵 크기 조절
[마인드맵_크기_조절.webm](https://github.com/boostcampwm2023/and07-MindSync/assets/39490416/15eb5790-76fe-4a69-847a-a4be33813a4a)


