### PR TITLE
노드 간 중첩 현상 해결

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/MindMapContainer.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/MindMapContainer.kt
@@ -1,6 +1,7 @@
 package boostcamp.and07.mindsync.ui.view
 
 import android.content.Context
+import boostcamp.and07.mindsync.data.model.CircleNode
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.ui.view.layout.MeasureTextSize
 import boostcamp.and07.mindsync.ui.view.layout.MindMapRightLayoutManager
@@ -24,7 +25,7 @@ class MindMapContainer(context: Context) {
     }
 
     fun updateHead(head: Node) {
-        this.head = rightLayoutManager.arrangeNode(measureTextSize.traverseTextHead(head))
+        this.head = rightLayoutManager.arrangeNode(measureTextSize.traverseTextHead(head) as CircleNode)
         nodeUpdateListener?.updateHead(head)
     }
 

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindMapRightLayoutManager.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindMapRightLayoutManager.kt
@@ -1,7 +1,6 @@
 package boostcamp.and07.mindsync.ui.view.layout
 
 import boostcamp.and07.mindsync.data.model.CircleNode
-import boostcamp.and07.mindsync.data.model.CirclePath
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.data.model.RectangleNode
 import boostcamp.and07.mindsync.ui.util.Dp
@@ -16,7 +15,7 @@ class MindMapRightLayoutManager {
         if (head.path.centerX.dpVal <= (totalHeight / 2).dpVal) {
             val newPath =
                 head.path.copy(
-                    centerY = totalHeight / 2 + horizontalSpacing
+                    centerY = totalHeight / 2 + horizontalSpacing,
                 )
             newHead = newHead.copy(path = newPath)
         }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindMapRightLayoutManager.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindMapRightLayoutManager.kt
@@ -10,7 +10,20 @@ class MindMapRightLayoutManager {
     private val horizontalSpacing = Dp(50f)
     private val verticalSpacing = Dp(50f)
 
-    fun arrangeNode(node: Node): Node {
+    fun arrangeNode(head: CircleNode): Node {
+        val totalHeight = measureChildHeight(head)
+        var newHead = head
+        if (head.path.centerX.dpVal <= (totalHeight / 2).dpVal) {
+            val newPath =
+                head.path.copy(
+                    centerY = totalHeight / 2 + horizontalSpacing
+                )
+            newHead = newHead.copy(path = newPath)
+        }
+        return recurArrangeNode(newHead)
+    }
+
+    private fun recurArrangeNode(node: Node): Node {
         val childHeightSum = measureChildHeight(node)
         val newNodes = mutableListOf<RectangleNode>()
 
@@ -20,11 +33,9 @@ class MindMapRightLayoutManager {
                 is CircleNode -> node.path.radius
             }
 
-        val criteriaX = node.path.centerX + nodeWidth + horizontalSpacing
+        val criteriaX = node.path.centerX + nodeWidth / 2 + horizontalSpacing
         var startX: Dp
-        val newCenterY =
-            if (node.path.centerY.dpVal >= (childHeightSum / 2).dpVal) node.path.centerY else childHeightSum / 2
-        var startY = newCenterY - (childHeightSum / 2)
+        var startY = node.path.centerY - (childHeightSum / 2)
 
         node.nodes.forEach { childNode ->
             startX = criteriaX + (childNode.path.width / 2)
@@ -41,19 +52,13 @@ class MindMapRightLayoutManager {
         }
 
         newNodes.forEachIndexed { index, childNode ->
-            newNodes[index] = arrangeNode(childNode) as RectangleNode
+            newNodes[index] = recurArrangeNode(childNode) as RectangleNode
         }
         val newNode =
             when (node) {
                 is RectangleNode -> node.copy(nodes = newNodes)
                 is CircleNode -> {
                     node.copy(
-                        path =
-                            CirclePath(
-                                centerX = node.path.centerX,
-                                centerY = newCenterY,
-                                radius = node.path.radius,
-                            ),
                         nodes = newNodes,
                     )
                 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindMapRightLayoutManager.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/layout/MindMapRightLayoutManager.kt
@@ -30,8 +30,8 @@ class MindMapRightLayoutManager {
             startX = criteriaX + (childNode.path.width / 2)
 
             val childHeight = measureChildHeight(childNode)
-            val newCenterY = startY + (childHeight / 2)
-            val newPath = childNode.path.copy(centerX = startX, centerY = newCenterY)
+            val newY = startY + (childHeight / 2)
+            val newPath = childNode.path.copy(centerX = startX, centerY = newY)
 
             newNodes.add(
                 childNode.copy(path = newPath),


### PR DESCRIPTION
## 관련 이슈
- #81 
## 작업한 내용
- **문제점**
한 노드의 길이가 길 때, 노드의 중첩현상이 일어났다.
- **원인**
  arrangeNode에서 노드의 위치를 자식의 높이 / 2 로 바꾸는 경우 해당 오류가 발생했다.
- **해결과정**
 처음엔 `measureChildHeight` 노드의 크기를 잴 때 자신의 크기와 자식의 크기 중 더 큰 값을 반환해 해결하려 했으나,
중첩현상은 해결되어도 노드의 위치가 조금 이상해서 알고리즘을 살펴보니 크기 측정부분의 문제가 아니라 `arrangeNode`에서 매번 노드의 위치를 상대적인 값이 아니라, 자식의 위치값 기준으로 바꿔주는 것이 문제였다.
해당 코드는 당시 화면의 크기가 늘어나면 헤드의 위치가 내려가야 잘리지 않아서 추가했던 코드이므로, 헤드의 위치만 내려가도록 함수를 수정했다.
- **그래서 해결한 방법은?**
`arragneNode`에서 `head`를 먼저 바꿔주고 recurArrangeNode를 호출하도록 수정했다.
- **해결된 모습**
  <img width="200" alt="스크린샷 2023-11-26 오전 1 51 49" src="https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/f54c65a3-2f9e-4dc7-b973-6a45cab1b5dc">