### PR TITLE
마인드맵 실시간 양방향 그리기 구현

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/crdt/Operation.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/crdt/Operation.kt
@@ -25,7 +25,14 @@ data class SerializedOperation(
     val parentId: String? = null,
 )
 
-abstract class Operation(val operationType: String, val id: String, val clock: Clock) {
+enum class OperationType(val command: String) {
+    ADD("add"),
+    DELETE("delete"),
+    MOVE("move"),
+    UPDATE("update"),
+}
+
+sealed class Operation(val operationType: String, val id: String, val clock: Clock) {
     abstract fun doOperation(tree: Tree): OperationLog
 
     abstract fun undoOperation(
@@ -39,7 +46,8 @@ abstract class Operation(val operationType: String, val id: String, val clock: C
     ): OperationLog
 }
 
-class OperationAdd(private val input: OperationInput) : Operation("add", input.id, input.clock) {
+class OperationAdd(input: OperationInput) :
+    Operation(OperationType.ADD.command, input.id, input.clock) {
     val parentId = input.parentId
     val description = input.description
 
@@ -66,7 +74,8 @@ class OperationAdd(private val input: OperationInput) : Operation("add", input.i
     }
 }
 
-class OperationDelete(input: OperationInput) : Operation("delete", input.id, input.clock) {
+class OperationDelete(input: OperationInput) :
+    Operation(OperationType.DELETE.command, input.id, input.clock) {
     override fun doOperation(tree: Tree): OperationLog {
         val node = tree.getNode(id)
         val oldParentId = node.parentId
@@ -87,7 +96,8 @@ class OperationDelete(input: OperationInput) : Operation("delete", input.id, inp
     ) = log.operation.doOperation(tree)
 }
 
-class OperationMove(private val input: OperationInput) : Operation("move", input.id, input.clock) {
+class OperationMove(input: OperationInput) :
+    Operation(OperationType.MOVE.command, input.id, input.clock) {
     val parentId = input.parentId
 
     override fun doOperation(tree: Tree): OperationLog {
@@ -112,8 +122,8 @@ class OperationMove(private val input: OperationInput) : Operation("move", input
     ) = log.operation.doOperation(tree)
 }
 
-class OperationUpdate(private val input: OperationInput) :
-    Operation("update", input.id, input.clock) {
+class OperationUpdate(input: OperationInput) :
+    Operation(OperationType.UPDATE.command, input.id, input.clock) {
     val description = input.description
 
     override fun doOperation(tree: Tree): OperationLog {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/Tree.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/model/Tree.kt
@@ -2,6 +2,7 @@ package boostcamp.and07.mindsync.data.model
 
 import boostcamp.and07.mindsync.data.NodeGenerator
 import boostcamp.and07.mindsync.ui.util.Dp
+import boostcamp.and07.mindsync.ui.util.ExceptionMessage
 
 class Tree {
     private var _nodes: MutableMap<String, Node>
@@ -33,7 +34,7 @@ class Tree {
     }
 
     fun getRootNode(): CircleNode {
-        _nodes[ROOT_ID] ?: throw IllegalArgumentException(ERROR_MESSAGE_ROOT_NODE_NOT_EXIST)
+        _nodes[ROOT_ID] ?: throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_ROOT_NODE_NOT_EXIST.message)
         return _nodes[ROOT_ID] as CircleNode
     }
 
@@ -49,7 +50,7 @@ class Tree {
     }
 
     fun getNode(id: String): Node {
-        return _nodes[id] ?: throw IllegalArgumentException(ERROR_MESSAGE_INVALID_NODE_ID)
+        return _nodes[id] ?: throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_INVALID_NODE_ID.message)
     }
 
     fun addNode(
@@ -57,13 +58,13 @@ class Tree {
         parentId: String?,
         content: String,
     ) {
-        if (_nodes[targetId] != null) throw IllegalArgumentException(ERROR_MESSAGE_DUPLICATED_NODE)
-        if (parentId == null) throw IllegalArgumentException(ERROR_MESSAGE_PARENT_NODE_NOT_EXIST)
+        if (_nodes[targetId] != null) throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_DUPLICATED_NODE.message)
+        if (parentId == null) throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_PARENT_NODE_NOT_EXIST.message)
         val newNode =
             NodeGenerator.makeNode(content, parentId).copy(id = targetId, parentId = parentId)
         val parentNode =
             _nodes[parentId] ?: throw IllegalArgumentException(
-                ERROR_MESSAGE_PARENT_NODE_NOT_EXIST,
+                ExceptionMessage.ERROR_MESSAGE_PARENT_NODE_NOT_EXIST.message,
             )
         val newChildren = parentNode.children.toMutableList()
         newChildren.add(targetId)
@@ -102,13 +103,13 @@ class Tree {
     }
 
     fun removeNode(targetId: String) {
-        if (targetId == ROOT_ID) throw IllegalArgumentException(ERROR_MESSAGE_ROOT_CANT_REMOVE)
+        if (targetId == ROOT_ID) throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_ROOT_CANT_REMOVE.message)
         val targetNode =
-            _nodes[targetId] ?: throw IllegalArgumentException(ERROR_MESSAGE_TARGET_NODE_NOT_EXIST)
+            _nodes[targetId] ?: throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_TARGET_NODE_NOT_EXIST.message)
         targetNode.parentId?.let { parentId ->
             val parentNode =
                 _nodes[parentId] ?: throw IllegalArgumentException(
-                    ERROR_MESSAGE_PARENT_NODE_NOT_EXIST,
+                    ExceptionMessage.ERROR_MESSAGE_PARENT_NODE_NOT_EXIST.message,
                 )
             val newChildren = parentNode.children.filter { id -> id != targetId }
             val newParent =
@@ -118,7 +119,7 @@ class Tree {
                     is RectangleNode -> parentNode.copy(children = newChildren)
                 }
             _nodes[parentId] = newParent
-        } ?: throw IllegalArgumentException(ERROR_MESSAGE_ROOT_CANT_REMOVE)
+        } ?: throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_ROOT_CANT_REMOVE.message)
     }
 
     fun updateNode(
@@ -126,7 +127,7 @@ class Tree {
         description: String,
     ) {
         val targetNode =
-            _nodes[targetId] ?: throw IllegalArgumentException(ERROR_MESSAGE_TARGET_NODE_NOT_EXIST)
+            _nodes[targetId] ?: throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_TARGET_NODE_NOT_EXIST.message)
         val newTargetNode =
             when (targetNode) {
                 is CircleNode -> targetNode.copy(description = description)
@@ -158,11 +159,5 @@ class Tree {
 
     companion object {
         private const val ROOT_ID = "root"
-        private const val ERROR_MESSAGE_INVALID_NODE_ID = "Node Id is invalid"
-        private const val ERROR_MESSAGE_DUPLICATED_NODE = "Target node is duplicated"
-        private const val ERROR_MESSAGE_TARGET_NODE_NOT_EXIST = "Target Node is not exist"
-        private const val ERROR_MESSAGE_PARENT_NODE_NOT_EXIST = "Parent Node is not exist"
-        private const val ERROR_MESSAGE_ROOT_NODE_NOT_EXIST = "Root Node is not exist"
-        private const val ERROR_MESSAGE_ROOT_CANT_REMOVE = "Root can't remove"
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/network/MindMapSocketManager.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/network/MindMapSocketManager.kt
@@ -93,7 +93,7 @@ enum class SocketState {
 
 data class SocketEvent(
     val eventType: SocketEventType,
-    val data: Any,
+    val operation: Any,
 )
 
 enum class SocketEventType {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import boostcamp.and07.mindsync.R
 import boostcamp.and07.mindsync.data.NodeGenerator
+import boostcamp.and07.mindsync.data.crdt.SerializedOperation
 import boostcamp.and07.mindsync.data.model.CircleNode
 import boostcamp.and07.mindsync.data.model.Node
 import boostcamp.and07.mindsync.data.model.RectangleNode
@@ -35,7 +36,7 @@ class MindMapFragment :
     override fun initView() {
         setupRootNode()
         setBinding()
-        collectTree()
+        collectOperation()
         collectSelectedNode()
         collectSocketState()
         collectSocketEvent()
@@ -67,10 +68,23 @@ class MindMapFragment :
                 event?.let { socketEvent ->
                     when (socketEvent.eventType) {
                         SocketEventType.OPERATION_FROM_SERVER -> {
-                            Log.d("MindMapFragment", "receive data: ${socketEvent.operation}")
+                            val operation = socketEvent.operation
+                            if (operation is SerializedOperation) {
+                                mindMapViewModel.applyOperation(operation)
+                            }
                         }
                     }
                 }
+            }
+        }
+    }
+
+    private fun collectOperation() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            mindMapViewModel.operation.collectLatest {
+                mindMapContainer.update(mindMapViewModel.crdtTree.tree)
+                binding.zoomLayoutMindMapRoot.lineView.updateTree(mindMapContainer.tree)
+                binding.zoomLayoutMindMapRoot.nodeView.updateTree(mindMapContainer.tree)
             }
         }
     }
@@ -89,16 +103,6 @@ class MindMapFragment :
         mindMapContainer.setTreeUpdateListener(this)
         binding.zoomLayoutMindMapRoot.mindMapContainer = mindMapContainer
         binding.zoomLayoutMindMapRoot.initializeZoomLayout()
-    }
-
-    private fun collectTree() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            mindMapViewModel.tree.collectLatest { newTree ->
-                mindMapContainer.update(newTree)
-                binding.zoomLayoutMindMapRoot.lineView.updateTree(mindMapContainer.tree)
-                binding.zoomLayoutMindMapRoot.nodeView.updateTree(mindMapContainer.tree)
-            }
-        }
     }
 
     private fun collectSelectedNode() {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
@@ -68,7 +68,7 @@ class MindMapFragment :
                 event?.let { socketEvent ->
                     when (socketEvent.eventType) {
                         SocketEventType.OPERATION_FROM_SERVER -> {
-                            Log.d("MindMapFragment", "receive data: ${socketEvent.data}")
+                            Log.d("MindMapFragment", "receive data: ${socketEvent.operation}")
                         }
                     }
                 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
@@ -47,7 +47,6 @@ class MindMapFragment :
                 when (state) {
                     SocketState.CONNECT -> {
                         mindMapViewModel.joinBoard(boardId)
-                        mindMapViewModel.updateMindMap(boardId)
                     }
 
                     SocketState.DISCONNECT -> {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -65,9 +65,11 @@ class MindMapViewModel : ViewModel() {
         parent: Node,
         addNode: RectangleNode,
     ) {
-        val newTree = _tree.value.copy(_tree.value.nodes)
-        newTree.addNode(addNode.id, parent.id, addNode.description)
-        _tree.value = newTree
+        val addOperation =
+            crdtTree.generateOperationAdd(addNode.id, parent.id, addNode.description)
+        crdtTree.applyOperation(addOperation)
+        _operation.value = addOperation
+        requestUpdateMindMap(operation = addOperation)
     }
 
     fun removeNode(target: Node) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -18,6 +18,7 @@ import boostcamp.and07.mindsync.network.MindMapSocketManager
 import boostcamp.and07.mindsync.network.SocketEvent
 import boostcamp.and07.mindsync.network.SocketState
 import boostcamp.and07.mindsync.ui.util.Dp
+import boostcamp.and07.mindsync.ui.util.ExceptionMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -109,7 +110,7 @@ class MindMapViewModel : ViewModel() {
                 OperationType.UPDATE.command -> crdtTree.deserializeOperationUpdate(operation)
                 OperationType.MOVE.command -> crdtTree.deserializeOperationMove(operation)
                 else -> {
-                    throw IllegalArgumentException("Operation is not defined")
+                    throw IllegalArgumentException(ExceptionMessage.ERROR_MESSAGE_NOT_DEFINED_OPERATION.message)
                 }
             }
         crdtTree.applyOperation(operation)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -74,9 +74,10 @@ class MindMapViewModel : ViewModel() {
 
     fun removeNode(target: Node) {
         _selectedNode.value = null
-        val newTree = _tree.value.copy(_tree.value.nodes)
-        newTree.removeNode(target.id)
-        _tree.value = newTree
+        val removeOperation = crdtTree.generateOperationDelete(target.id)
+        crdtTree.applyOperation(removeOperation)
+        _operation.value = removeOperation
+        requestUpdateMindMap(operation = removeOperation)
     }
 
     fun setSelectedNode(selectNode: Node?) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -117,9 +117,11 @@ class MindMapViewModel : ViewModel() {
     }
 
     fun updateNode(updateNode: Node) {
-        val newTree = _tree.value.copy(_tree.value.nodes)
-        newTree.updateNode(updateNode.id, updateNode.description)
-        _tree.value = newTree
+        val updateOperation =
+            crdtTree.generateOperationUpdate(updateNode.id, updateNode.description)
+        crdtTree.applyOperation(updateOperation)
+        _operation.value = updateOperation
+        requestUpdateMindMap(updateOperation)
     }
 
     fun update(newTree: Tree) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/ExceptionMessage.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/ExceptionMessage.kt
@@ -1,0 +1,11 @@
+package boostcamp.and07.mindsync.ui.util
+
+enum class ExceptionMessage(val message: String) {
+    ERROR_MESSAGE_INVALID_NODE_ID("Node Id is invalid"),
+    ERROR_MESSAGE_DUPLICATED_NODE("Target node is duplicated"),
+    ERROR_MESSAGE_TARGET_NODE_NOT_EXIST("Target Node is not exist"),
+    ERROR_MESSAGE_PARENT_NODE_NOT_EXIST("Parent Node is not exist"),
+    ERROR_MESSAGE_ROOT_NODE_NOT_EXIST("Root Node is not exist"),
+    ERROR_MESSAGE_ROOT_CANT_REMOVE("Root can't remove"),
+    ERROR_MESSAGE_NOT_DEFINED_OPERATION("Operation is not defined"),
+}


### PR DESCRIPTION
## 관련 이슈
- #98 
## 작업한 내용
- 하드코딩된 operationType을 enum class로 분리
- viewModel의 flow를 operation으로 변경
- 클라이언트의 Operation 적용 및 서버 전송
- 서버로 받은 Operation 적용
   -  Add
   - Delete
   - Update
- SocketEvent data ->  operation으로 이름 변경
## 시연영상
[시연영상](https://github.com/boostcampwm2023/and07-MindSync/assets/99114456/c4235de4-1512-455a-b294-c1740591ef47)