### PR TITLE
refresh 토큰 생성 및 검증 추가

### DIFF
--- a/nestjs-BE/server/prisma/migrations/20231205080004_init/migration.sql
+++ b/nestjs-BE/server/prisma/migrations/20231205080004_init/migration.sql
@@ -2,9 +2,20 @@
 CREATE TABLE `USER_TB` (
     `uuid` VARCHAR(32) NOT NULL,
     `email` VARCHAR(191) NOT NULL,
-    `password` VARCHAR(191) NOT NULL,
+    `provider` VARCHAR(191) NOT NULL,
 
-    UNIQUE INDEX `USER_TB_email_key`(`email`),
+    UNIQUE INDEX `USER_TB_email_provider_key`(`email`, `provider`),
+    PRIMARY KEY (`uuid`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `REFRESH_TOKEN_TB` (
+    `uuid` VARCHAR(32) NOT NULL,
+    `token` VARCHAR(191) NOT NULL,
+    `expiry_date` DATETIME(3) NOT NULL,
+    `user_id` VARCHAR(191) NOT NULL,
+
+    UNIQUE INDEX `REFRESH_TOKEN_TB_token_key`(`token`),
     PRIMARY KEY (`uuid`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
@@ -35,6 +46,9 @@ CREATE TABLE `PROFILE_SPACE_TB` (
 
     PRIMARY KEY (`space_uuid`, `profile_uuid`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `REFRESH_TOKEN_TB` ADD CONSTRAINT `REFRESH_TOKEN_TB_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `USER_TB`(`uuid`) ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE `PROFILE_TB` ADD CONSTRAINT `PROFILE_TB_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `USER_TB`(`uuid`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/nestjs-BE/server/prisma/mysql.schema.prisma
+++ b/nestjs-BE/server/prisma/mysql.schema.prisma
@@ -10,9 +10,19 @@ datasource db {
 
 model USER_TB {
   uuid     String      @id @db.VarChar(32)
-  email    String      @unique
-  password String
-  profiles PROFILE_TB[] 
+  email    String
+  provider String
+  profiles PROFILE_TB[]
+  refresh_tokens REFRESH_TOKEN_TB[]
+  @@unique([email, provider])
+}
+
+model REFRESH_TOKEN_TB {
+  uuid       String      @id @db.VarChar(32)
+  token      String    @unique
+  expiry_date DateTime
+  user_id    String
+  user       USER_TB   @relation(fields: [user_id], references: [uuid])
 }
 
 model PROFILE_TB {
@@ -39,3 +49,4 @@ model PROFILE_SPACE_TB {
   profile      PROFILE_TB @relation(fields: [profile_uuid], references: [uuid])
   @@id([space_uuid, profile_uuid])
 }
+

--- a/nestjs-BE/server/src/auth/auth.controller.ts
+++ b/nestjs-BE/server/src/auth/auth.controller.ts
@@ -35,6 +35,17 @@ export class AuthController {
     return this.authService.login(user);
   }
 
+  @Post('token')
+  @Public()
+  renewAccessToken(@Body('refresh_token') refreshToken) {
+    return this.authService.renewAccessToken(refreshToken);
+  }
+
+  @Post('logout')
+  logout(@Body('refresh_token') refreshToken) {
+    return this.authService.remove(refreshToken);
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get('profile')
   getProfile(@Request() req) {

--- a/nestjs-BE/server/src/auth/auth.service.ts
+++ b/nestjs-BE/server/src/auth/auth.service.ts
@@ -1,11 +1,42 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { kakaoOauthConstants } from './constants';
+import { jwtConstants, kakaoOauthConstants } from './constants';
 import { stringify } from 'qs';
+import { PrismaServiceMySQL } from 'src/prisma/prisma.service';
+import { TemporaryDatabaseService } from 'src/temporary-database/temporary-database.service';
+import { BaseService } from 'src/base/base.service';
+import {
+  REFRESH_TOKEN_CACHE_SIZE,
+  REFRESH_TOKEN_EXPIRY_DAYS,
+} from 'src/config/magic-number';
+import generateUuid from 'src/utils/uuid';
+
+interface TokenData {
+  uuid?: string;
+  token: string;
+  expiry_date: Date;
+  user_id: string;
+}
 
 @Injectable()
-export class AuthService {
-  constructor(private jwtService: JwtService) {}
+export class AuthService extends BaseService<TokenData> {
+  constructor(
+    private jwtService: JwtService,
+    protected prisma: PrismaServiceMySQL,
+    protected temporaryDatabaseService: TemporaryDatabaseService,
+  ) {
+    super({
+      prisma,
+      temporaryDatabaseService,
+      cacheSize: REFRESH_TOKEN_CACHE_SIZE,
+      className: 'REFRESH_TOKEN_TB',
+      field: 'token',
+    });
+  }
+
+  generateKey(data: TokenData): string {
+    return data.token;
+  }
 
   async getKakaoAccount(kakaoUserId: number) {
     const url = `https://kapi.kakao.com/v2/user/me`;
@@ -23,8 +54,61 @@ export class AuthService {
     return responseBody.kakao_account;
   }
 
+  async createAccessToken(userUuid: string): Promise<string> {
+    const payload = { sub: userUuid };
+    const accessToken = await this.jwtService.signAsync(payload);
+    return accessToken;
+  }
+
+  async createRefreshToken(): Promise<string> {
+    const refreshTokenPayload = { uuid: generateUuid() };
+    const refreshToken = await this.jwtService.signAsync(refreshTokenPayload, {
+      secret: jwtConstants.secret,
+      expiresIn: '14d',
+    });
+    return refreshToken;
+  }
+
+  createRefreshTokenData(refreshToken: string, userUuid: string) {
+    const currentDate = new Date();
+    const expiryDate = new Date(currentDate);
+    expiryDate.setDate(currentDate.getDate() + REFRESH_TOKEN_EXPIRY_DAYS);
+    const refreshTokenData: TokenData = {
+      token: refreshToken,
+      expiry_date: expiryDate,
+      user_id: userUuid,
+    };
+    return refreshTokenData;
+  }
+
   async login(user: any) {
-    const payload = { sub: user.uuid, email: user.email };
-    return { access_token: await this.jwtService.signAsync(payload) };
+    const refreshToken = await this.createRefreshToken();
+    const accessToken = await this.createAccessToken(user.uuid);
+    const refreshTokenData = this.createRefreshTokenData(
+      refreshToken,
+      user.uuid,
+    );
+    super.create(refreshTokenData);
+    return {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+    };
+  }
+
+  async renewAccessToken(refreshToken: string) {
+    try {
+      this.jwtService.verify(refreshToken, {
+        secret: jwtConstants.secret,
+      });
+      const tokenData = await this.getDataFromCacheOrDB(refreshToken);
+      if (!tokenData) throw new Error('No token data found');
+      const accessToken = await this.createAccessToken(tokenData.user_id);
+      return accessToken;
+    } catch (error) {
+      super.remove(refreshToken);
+      throw new UnauthorizedException(
+        'Refresh token expired. Please log in again.',
+      );
+    }
   }
 }

--- a/nestjs-BE/server/src/auth/jwt.strategy.ts
+++ b/nestjs-BE/server/src/auth/jwt.strategy.ts
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { uuid: payload.sub, email: payload.email };
+    return { uuid: payload.sub };
   }
 }

--- a/nestjs-BE/server/src/config/magic-number.ts
+++ b/nestjs-BE/server/src/config/magic-number.ts
@@ -2,3 +2,5 @@ export const USER_CACHE_SIZE = 1000;
 export const PROFILE_CACHE_SIZE = 5000;
 export const SPACE_CACHE_SIZE = 10000;
 export const BOARD_CACHE_SIZE = 10000;
+export const REFRESH_TOKEN_CACHE_SIZE = 1000;
+export const REFRESH_TOKEN_EXPIRY_DAYS = 14;

--- a/nestjs-BE/server/src/temporary-database/temporary-database.service.ts
+++ b/nestjs-BE/server/src/temporary-database/temporary-database.service.ts
@@ -36,6 +36,7 @@ export class TemporaryDatabaseService {
       'SPACE_TB',
       'BoardCollection',
       'PROFILE_SPACE_TB',
+      'REFRESH_TOKEN_TB',
     ];
     const operations = ['insert', 'update', 'delete'];
 

--- a/nestjs-BE/server/src/users/dto/create-user.dto.ts
+++ b/nestjs-BE/server/src/users/dto/create-user.dto.ts
@@ -4,6 +4,6 @@ export class CreateUserDto {
   @ApiProperty({ example: 'test@gmail.com', description: 'email adress' })
   readonly email: string;
 
-  @ApiProperty({ example: 'qwerasdf@!123', description: 'password' })
-  readonly password: string;
+  @ApiProperty({ example: 'kakao', description: 'social site name' })
+  readonly provider: string;
 }

--- a/nestjs-BE/server/src/users/users.service.ts
+++ b/nestjs-BE/server/src/users/users.service.ts
@@ -51,7 +51,7 @@ export class UsersService extends BaseService<UpdateUserDto> {
       temporaryDatabaseService,
       cacheSize: USER_CACHE_SIZE,
       className: 'USER_TB',
-      field: 'email',
+      field: 'email_provider',
     });
   }
 
@@ -65,8 +65,8 @@ export class UsersService extends BaseService<UpdateUserDto> {
     this.users.push({ uuid: v4(), email });
   }
 
-  generateKey(data: UpdateUserDto): string {
-    return data.email;
+  generateKey(data: UpdateUserDto) {
+    return `email:${data.email}+provider:${data.provider}`;
   }
 
   async findProfiles(email: string, includeSpaces = false) {


### PR DESCRIPTION
## 관련 이슈
- #133 
## 작업한 내용
- 테이블 변경 및 cloud database 테이블 생성
- refresh token
    - refresh token은 아무 uuid를 payload에 넣고, 생성하는 식으로 추가
    - key : refresh token : value : userUuid를 찾을 수 있도록 추가
    - 애초에 시간이 만료 됐으면 db까지 찾지 않고 바로 db에 삭제되도록 구현
    - 만료 됐을 시 401 에러와 함께 메세지 추가
    - 만료 안됐을 시 새로운 access token 발급되도록 구현