### PR TITLE
RootNode가 이동 상태가 되는 버그 수정

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -56,7 +56,7 @@ class NodeView(
             }
 
             MotionEvent.ACTION_MOVE -> {
-                mindMapContainer.isMoving = true
+                mindMapContainer.isMoving = mindMapContainer.selectNode is RectangleNode
                 moveNode(
                     event.x,
                     event.y,
@@ -104,6 +104,7 @@ class NodeView(
         dy: Float,
     ) {
         var attachedNode: Node? = null
+        if (mindMapContainer.selectNode is CircleNode) return
         mindMapContainer.tree.doPreorderTraversal { node ->
             mindMapContainer.selectNode?.let {
                 if (isInsideNode(node, dx, dy) && mindMapContainer.selectNode?.id != node.id) {
@@ -170,7 +171,11 @@ class NodeView(
             target.path.centerY,
         )
         node.children.forEach { nodeId ->
-            traverseChildNode(node, tree.getNode(nodeId), childNodeSpacing + CHILD_NODE_SPACING_VALUE)
+            traverseChildNode(
+                node,
+                tree.getNode(nodeId),
+                childNodeSpacing + CHILD_NODE_SPACING_VALUE,
+            )
         }
     }
 
@@ -220,9 +225,9 @@ class NodeView(
                     radius,
                     drawInfo.boundaryPaint,
                 )
+                invalidate()
             }
         }
-        invalidate()
     }
 
     private fun makeStrokeNode(
@@ -258,8 +263,12 @@ class NodeView(
     ): Boolean {
         when (node) {
             is CircleNode -> {
-                if (x in (node.path.centerX - node.path.radius).toPx(context)..(node.path.centerX + node.path.radius).toPx(context) &&
-                    y in (node.path.centerY - node.path.radius).toPx(context)..(node.path.centerY + node.path.radius).toPx(context)
+                if (x in (node.path.centerX - node.path.radius).toPx(context)..(node.path.centerX + node.path.radius).toPx(
+                        context,
+                    ) &&
+                    y in (node.path.centerY - node.path.radius).toPx(context)..(node.path.centerY + node.path.radius).toPx(
+                        context,
+                    )
                 ) {
                     return true
                 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -215,14 +215,16 @@ class NodeView(
 
     private fun drawAttachedNode(canvas: Canvas) {
         attachedNode?.let { attachedNode ->
-            val height = when (attachedNode) {
-                is RectangleNode -> attachedNode.path.height
-                is CircleNode -> attachedNode.path.radius + Dp(ATTACH_CIRCLE_NODE_RANGE_VALUE)
-            }
-            val width = when (attachedNode) {
-                is RectangleNode -> attachedNode.path.width
-                is CircleNode -> attachedNode.path.radius + Dp(ATTACH_CIRCLE_NODE_RANGE_VALUE)
-            }
+            val height =
+                when (attachedNode) {
+                    is RectangleNode -> attachedNode.path.height
+                    is CircleNode -> attachedNode.path.radius + Dp(ATTACH_CIRCLE_NODE_RANGE_VALUE)
+                }
+            val width =
+                when (attachedNode) {
+                    is RectangleNode -> attachedNode.path.width
+                    is CircleNode -> attachedNode.path.radius + Dp(ATTACH_CIRCLE_NODE_RANGE_VALUE)
+                }
             val radius = maxOf(height.toPx(context), width.toPx(context))
             canvas.drawCircle(
                 attachedNode.path.centerX.toPx(context),
@@ -267,12 +269,8 @@ class NodeView(
     ): Boolean {
         when (node) {
             is CircleNode -> {
-                if (x in (node.path.centerX - node.path.radius).toPx(context)..(node.path.centerX + node.path.radius).toPx(
-                        context,
-                    ) &&
-                    y in (node.path.centerY - node.path.radius).toPx(context)..(node.path.centerY + node.path.radius).toPx(
-                        context,
-                    )
+                if (x in (node.path.centerX - node.path.radius).toPx(context)..(node.path.centerX + node.path.radius).toPx(context) &&
+                    y in (node.path.centerY - node.path.radius).toPx(context)..(node.path.centerY + node.path.radius).toPx(context)
                 ) {
                     return true
                 }
@@ -339,9 +337,7 @@ class NodeView(
                 drawInfo.textPaint.color = Color.WHITE
                 if (lines.size > 1) {
                     var y =
-                        node.path.centerY.toPx(context) - node.path.radius.toPx(context) / 2 + drawInfo.padding.toPx(
-                            context,
-                        ) / 2
+                        node.path.centerY.toPx(context) - node.path.radius.toPx(context) / 2 + drawInfo.padding.toPx(context) / 2
                     for (line in lines) {
                         drawInfo.textPaint.getTextBounds(line, 0, line.length, bounds)
                         canvas.drawText(
@@ -366,9 +362,7 @@ class NodeView(
                 drawInfo.textPaint.color = Color.BLACK
                 if (lines.size > 1) {
                     var y =
-                        node.path.centerY.toPx(context) - node.path.height.toPx(context) / 2 + drawInfo.padding.toPx(
-                            context,
-                        ) / 2
+                        node.path.centerY.toPx(context) - node.path.height.toPx(context) / 2 + drawInfo.padding.toPx(context) / 2
                     for (line in lines) {
                         drawInfo.textPaint.getTextBounds(line, 0, line.length, bounds)
                         canvas.drawText(

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -215,18 +215,22 @@ class NodeView(
 
     private fun drawAttachedNode(canvas: Canvas) {
         attachedNode?.let { attachedNode ->
-            if (attachedNode is RectangleNode) {
-                val height = attachedNode.path.height
-                val width = attachedNode.path.width
-                val radius = maxOf(height.toPx(context), width.toPx(context))
-                canvas.drawCircle(
-                    attachedNode.path.centerX.toPx(context),
-                    attachedNode.path.centerY.toPx(context),
-                    radius,
-                    drawInfo.boundaryPaint,
-                )
-                invalidate()
+            val height = when (attachedNode) {
+                is RectangleNode -> attachedNode.path.height
+                is CircleNode -> attachedNode.path.radius + Dp(ATTACH_CIRCLE_NODE_RANGE_VALUE)
             }
+            val width = when (attachedNode) {
+                is RectangleNode -> attachedNode.path.width
+                is CircleNode -> attachedNode.path.radius + Dp(ATTACH_CIRCLE_NODE_RANGE_VALUE)
+            }
+            val radius = maxOf(height.toPx(context), width.toPx(context))
+            canvas.drawCircle(
+                attachedNode.path.centerX.toPx(context),
+                attachedNode.path.centerY.toPx(context),
+                radius,
+                drawInfo.boundaryPaint,
+            )
+            invalidate()
         }
     }
 
@@ -390,5 +394,6 @@ class NodeView(
     companion object {
         private const val DEFAULT_SPACING_VALUE = 50f
         private const val CHILD_NODE_SPACING_VALUE = 7f
+        private const val ATTACH_CIRCLE_NODE_RANGE_VALUE = 15f
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/view/NodeView.kt
@@ -40,7 +40,7 @@ class NodeView(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-        drawAttachedNodeNode(canvas)
+        drawAttachedNode(canvas)
         drawTree(canvas)
         mindMapContainer.selectNode?.let { selectedNode ->
             makeStrokeNode(canvas, selectedNode)
@@ -213,7 +213,7 @@ class NodeView(
         invalidate()
     }
 
-    private fun drawAttachedNodeNode(canvas: Canvas) {
+    private fun drawAttachedNode(canvas: Canvas) {
         attachedNode?.let { attachedNode ->
             if (attachedNode is RectangleNode) {
                 val height = attachedNode.path.height


### PR DESCRIPTION
## 관련 이슈
- #236 

## 작업한 내용
- RootNode가 이동상태로 되어 다른 노드에 범위가 보이는 현상 수정
- 다른 노드를 RootNode에 이동하려고 할 때 범위가 보이도록 구현
 
[Screen_recording_20231211_154618.webm](https://github.com/boostcampwm2023/and07-MindSync/assets/39490416/abfaee33-323a-4c91-b857-5a7165194b23)

[Screen_recording_20231211_155006.webm](https://github.com/boostcampwm2023/and07-MindSync/assets/39490416/c71a118b-1576-4c38-9643-885d5161a388)
