### PR TITLE
throttleFirst 적용하기

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListFragment.kt
@@ -10,6 +10,7 @@ import boostcamp.and07.mindsync.R
 import boostcamp.and07.mindsync.data.model.Board
 import boostcamp.and07.mindsync.databinding.FragmentBoardListBinding
 import boostcamp.and07.mindsync.ui.base.BaseFragment
+import boostcamp.and07.mindsync.ui.util.setClickEvent
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -73,7 +74,7 @@ class BoardListFragment :
     }
 
     private fun onFloatingButtonClick() {
-        binding.btnBoardListAddBoard.setOnClickListener {
+        binding.btnBoardListAddBoard.setClickEvent(lifecycleScope) {
             if (boardListViewModel.boardUiState.value.selectBoards.isEmpty()) {
                 val createBoardDialog = CreateBoardDialog()
                 createBoardDialog.setCompleteListener { part, name ->

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/CreateBoardDialog.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/CreateBoardDialog.kt
@@ -24,8 +24,10 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat.checkSelfPermission
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import boostcamp.and07.mindsync.R
 import boostcamp.and07.mindsync.databinding.DialogCreateBoardBinding
+import boostcamp.and07.mindsync.ui.util.setClickEvent
 import boostcamp.and07.mindsync.ui.util.toAbsolutePath
 import dagger.hilt.android.AndroidEntryPoint
 import okhttp3.MultipartBody
@@ -82,6 +84,7 @@ class CreateBoardDialog : DialogFragment() {
     ): View {
         _binding = DialogCreateBoardBinding.inflate(inflater, container, false)
         setBinding()
+        setClickEventThrottle()
         return binding.root
     }
 
@@ -125,8 +128,10 @@ class CreateBoardDialog : DialogFragment() {
         dismiss()
     }
 
-    fun clickImageButton() {
-        checkPermissionsAndLaunchImagePicker()
+    private fun setClickEventThrottle() {
+        binding.imgbtnUpdateSpaceThumbnail.setClickEvent(lifecycleScope) {
+            checkPermissionsAndLaunchImagePicker()
+        }
     }
 
     private fun createImage(uri: Uri?) {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/InviteUserDialog.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/InviteUserDialog.kt
@@ -12,7 +12,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
@@ -64,7 +63,6 @@ class InviteUserDialog : DialogFragment() {
             spaceRepository.getInviteSpaceCode(args.spaceId)
                 .collectLatest { inviteCode ->
                     binding.tvInviteUserSpaceCode.text = inviteCode
-                    Toast.makeText(requireContext(), "성공!", Toast.LENGTH_SHORT).show()
                 }
         }
     }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainActivity.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainActivity.kt
@@ -20,6 +20,7 @@ import boostcamp.and07.mindsync.ui.base.BaseActivityViewModel
 import boostcamp.and07.mindsync.ui.boardlist.UsersAdapter
 import boostcamp.and07.mindsync.ui.profile.ProfileActivity
 import boostcamp.and07.mindsync.ui.space.list.SpaceListFragmentDirections
+import boostcamp.and07.mindsync.ui.util.ThrottleDuration
 import boostcamp.and07.mindsync.ui.util.setClickEvent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -92,7 +93,7 @@ class MainActivity :
 
     private fun setSideBarNavigation() {
         with(binding.includeMainInDrawer) {
-            tvSideBarBoardList.setClickEvent(lifecycleScope) {
+            tvSideBarBoardList.setClickEvent(lifecycleScope, ThrottleDuration.LONG_DURATION.duration) {
                 mainViewModel.uiState.value.nowSpace?.let { nowSpace ->
                     drawerLayout.closeDrawers()
                     navController.navigate(
@@ -109,17 +110,17 @@ class MainActivity :
                 }
             }
 
-            tvSideBarRecycleBin.setClickEvent(lifecycleScope) {
+            tvSideBarRecycleBin.setClickEvent(lifecycleScope, ThrottleDuration.LONG_DURATION.duration) {
                 drawerLayout.closeDrawers()
                 navController.navigate(R.id.action_to_recycleBinFragment)
             }
 
-            imgbtnSideBarAddSpace.setClickEvent(lifecycleScope) {
+            imgbtnSideBarAddSpace.setClickEvent(lifecycleScope, ThrottleDuration.LONG_DURATION.duration) {
                 drawerLayout.closeDrawers()
                 navController.navigate(R.id.action_to_addSpaceDialog)
             }
 
-            tvSideBarInviteSpace.setClickEvent(lifecycleScope) {
+            tvSideBarInviteSpace.setClickEvent(lifecycleScope, ThrottleDuration.LONG_DURATION.duration) {
                 mainViewModel.uiState.value.nowSpace?.let { nowSpace ->
                     drawerLayout.closeDrawers()
                     navController.navigate(
@@ -136,12 +137,12 @@ class MainActivity :
                 }
             }
 
-            imgbtnSideBarProfile.setClickEvent(lifecycleScope) {
+            imgbtnSideBarProfile.setClickEvent(lifecycleScope, ThrottleDuration.LONG_DURATION.duration) {
                 val intent = Intent(this@MainActivity, ProfileActivity::class.java)
                 startActivity(intent)
             }
 
-            tvSideBarLeaveSpace.setClickEvent(lifecycleScope) {
+            tvSideBarLeaveSpace.setClickEvent(lifecycleScope, ThrottleDuration.LONG_DURATION.duration) {
                 mainViewModel.leaveSpace()
                 // TODO : 보드 목록 화면으로 이동시키기
             }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainActivity.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainActivity.kt
@@ -20,6 +20,7 @@ import boostcamp.and07.mindsync.ui.base.BaseActivityViewModel
 import boostcamp.and07.mindsync.ui.boardlist.UsersAdapter
 import boostcamp.and07.mindsync.ui.profile.ProfileActivity
 import boostcamp.and07.mindsync.ui.space.list.SpaceListFragmentDirections
+import boostcamp.and07.mindsync.ui.util.setClickEvent
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -91,7 +92,7 @@ class MainActivity :
 
     private fun setSideBarNavigation() {
         with(binding.includeMainInDrawer) {
-            tvSideBarBoardList.setOnClickListener {
+            tvSideBarBoardList.setClickEvent(lifecycleScope) {
                 mainViewModel.uiState.value.nowSpace?.let { nowSpace ->
                     drawerLayout.closeDrawers()
                     navController.navigate(
@@ -107,15 +108,18 @@ class MainActivity :
                     ).show()
                 }
             }
-            tvSideBarRecycleBin.setOnClickListener {
+
+            tvSideBarRecycleBin.setClickEvent(lifecycleScope) {
                 drawerLayout.closeDrawers()
                 navController.navigate(R.id.action_to_recycleBinFragment)
             }
-            imgbtnSideBarAddSpace.setOnClickListener {
+
+            imgbtnSideBarAddSpace.setClickEvent(lifecycleScope) {
                 drawerLayout.closeDrawers()
                 navController.navigate(R.id.action_to_addSpaceDialog)
             }
-            tvSideBarInviteSpace.setOnClickListener {
+
+            tvSideBarInviteSpace.setClickEvent(lifecycleScope) {
                 mainViewModel.uiState.value.nowSpace?.let { nowSpace ->
                     drawerLayout.closeDrawers()
                     navController.navigate(
@@ -131,11 +135,13 @@ class MainActivity :
                     ).show()
                 }
             }
-            imgbtnSideBarProfile.setOnClickListener {
+
+            imgbtnSideBarProfile.setClickEvent(lifecycleScope) {
                 val intent = Intent(this@MainActivity, ProfileActivity::class.java)
                 startActivity(intent)
             }
-            tvSideBarLeaveSpace.setOnClickListener {
+
+            tvSideBarLeaveSpace.setClickEvent(lifecycleScope) {
                 mainViewModel.leaveSpace()
                 // TODO : 보드 목록 화면으로 이동시키기
             }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
@@ -19,6 +19,7 @@ import boostcamp.and07.mindsync.ui.dialog.EditDescriptionDialog
 import boostcamp.and07.mindsync.ui.dialog.EditDialogInterface
 import boostcamp.and07.mindsync.ui.util.Dp
 import boostcamp.and07.mindsync.ui.util.Px
+import boostcamp.and07.mindsync.ui.util.setClickEvent
 import boostcamp.and07.mindsync.ui.util.toDp
 import boostcamp.and07.mindsync.ui.view.MindMapContainer
 import boostcamp.and07.mindsync.ui.view.listener.NodeClickListener
@@ -44,6 +45,7 @@ class MindMapFragment :
         collectOperation()
         collectSelectedNode()
         collectSocketState()
+        setClickEventThrottle()
         mindMapViewModel.setBoardId(args.boardId)
     }
 
@@ -88,7 +90,6 @@ class MindMapFragment :
 
     private fun setBinding() {
         binding.vm = mindMapViewModel
-        binding.view = this
         mindMapContainer = MindMapContainer(requireContext())
         mindMapContainer.setNodeClickListener(this)
         mindMapContainer.setTreeUpdateListener(this)
@@ -122,20 +123,32 @@ class MindMapFragment :
         dialog.show(requireActivity().supportFragmentManager, "EditDescriptionDialog")
     }
 
-    fun addButtonListener(selectNode: Node) {
-        showDialog(selectNode) { parent, description ->
-            mindMapViewModel.addNode(parent, NodeGenerator.makeNode(description, parent.id))
-        }
-    }
-
-    fun editButtonListener(selectNode: Node) {
-        showDialog(selectNode) { node, description ->
-            val newNode =
-                when (node) {
-                    is CircleNode -> node.copy(description = description)
-                    is RectangleNode -> node.copy(description = description)
+    private fun setClickEventThrottle() {
+        with(binding) {
+            imgbtnMindMapAdd.setClickEvent(lifecycleScope) {
+                mindMapViewModel.selectedNode.value?.let { selectNode ->
+                    showDialog(selectNode) { parent, description ->
+                        mindMapViewModel.addNode(parent, NodeGenerator.makeNode(description, parent.id))
+                    }
                 }
-            mindMapViewModel.updateNode(newNode)
+            }
+            imgbtnMindMapEdit.setClickEvent(lifecycleScope) {
+                mindMapViewModel.selectedNode.value?.let { selectNode ->
+                    showDialog(selectNode) { node, description ->
+                        val newNode =
+                            when (node) {
+                                is CircleNode -> node.copy(description = description)
+                                is RectangleNode -> node.copy(description = description)
+                            }
+                        mindMapViewModel.updateNode(newNode)
+                    }
+                }
+            }
+            imgbtnMindMapRemove.setClickEvent(lifecycleScope) {
+                mindMapViewModel.selectedNode.value?.let { selectNode ->
+                    mindMapViewModel.removeNode(selectNode)
+                }
+            }
         }
     }
 

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
@@ -19,6 +19,7 @@ import boostcamp.and07.mindsync.ui.dialog.EditDescriptionDialog
 import boostcamp.and07.mindsync.ui.dialog.EditDialogInterface
 import boostcamp.and07.mindsync.ui.util.Dp
 import boostcamp.and07.mindsync.ui.util.Px
+import boostcamp.and07.mindsync.ui.util.ThrottleDuration
 import boostcamp.and07.mindsync.ui.util.setClickEvent
 import boostcamp.and07.mindsync.ui.util.toDp
 import boostcamp.and07.mindsync.ui.view.MindMapContainer
@@ -125,14 +126,14 @@ class MindMapFragment :
 
     private fun setClickEventThrottle() {
         with(binding) {
-            imgbtnMindMapAdd.setClickEvent(lifecycleScope) {
+            imgbtnMindMapAdd.setClickEvent(lifecycleScope, ThrottleDuration.SHORT_DURATION.duration) {
                 mindMapViewModel.selectedNode.value?.let { selectNode ->
                     showDialog(selectNode) { parent, description ->
                         mindMapViewModel.addNode(parent, NodeGenerator.makeNode(description, parent.id))
                     }
                 }
             }
-            imgbtnMindMapEdit.setClickEvent(lifecycleScope) {
+            imgbtnMindMapEdit.setClickEvent(lifecycleScope, ThrottleDuration.SHORT_DURATION.duration) {
                 mindMapViewModel.selectedNode.value?.let { selectNode ->
                     showDialog(selectNode) { node, description ->
                         val newNode =
@@ -144,7 +145,7 @@ class MindMapFragment :
                     }
                 }
             }
-            imgbtnMindMapRemove.setClickEvent(lifecycleScope) {
+            imgbtnMindMapRemove.setClickEvent(lifecycleScope, ThrottleDuration.SHORT_DURATION.duration) {
                 mindMapViewModel.selectedNode.value?.let { selectNode ->
                     mindMapViewModel.removeNode(selectNode)
                 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/profile/ProfileFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/profile/ProfileFragment.kt
@@ -15,6 +15,7 @@ import boostcamp.and07.mindsync.data.repository.profile.ProfileRepository
 import boostcamp.and07.mindsync.databinding.FragmentProfileBinding
 import boostcamp.and07.mindsync.ui.base.BaseFragment
 import boostcamp.and07.mindsync.ui.util.ImagePickerHandler
+import boostcamp.and07.mindsync.ui.util.setClickEvent
 import boostcamp.and07.mindsync.ui.util.toAbsolutePath
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -41,7 +42,7 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>(R.layout.fragment_p
                 createImage(uri)
             }
         setBinding()
-        setupImageEdit()
+        setClickEventThrottle()
         setupShowNicknameEditBtn()
         setupBackBtn()
         observeEvent()
@@ -58,8 +59,8 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>(R.layout.fragment_p
         binding.vm = profileViewModel
     }
 
-    private fun setupImageEdit() {
-        binding.ivProfileImage.setOnClickListener {
+    private fun setClickEventThrottle() {
+        binding.ivProfileImage.setClickEvent(lifecycleScope) {
             imagePickerHandler.checkPermissionsAndLaunchImagePicker()
         }
     }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/space/generate/AddSpaceActivity.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/space/generate/AddSpaceActivity.kt
@@ -13,6 +13,7 @@ import boostcamp.and07.mindsync.ui.base.BaseActivityViewModel
 import boostcamp.and07.mindsync.ui.space.SpaceEvent
 import boostcamp.and07.mindsync.ui.util.ImagePickerHandler
 import boostcamp.and07.mindsync.ui.util.SpaceExceptionMessage
+import boostcamp.and07.mindsync.ui.util.setClickEvent
 import boostcamp.and07.mindsync.ui.util.toAbsolutePath
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,6 +33,7 @@ class AddSpaceActivity : BaseActivity<ActivityAddSpaceBinding>(R.layout.activity
         setBinding()
         setBackBtn()
         collectSpaceEvent()
+        setClickEventThrottle()
     }
 
     override fun getViewModel(): BaseActivityViewModel {
@@ -40,11 +42,12 @@ class AddSpaceActivity : BaseActivity<ActivityAddSpaceBinding>(R.layout.activity
 
     private fun setBinding() {
         binding.vm = addSpaceViewModel
-        binding.view = this
     }
 
-    fun clickImageButton() {
-        imagePickerHandler.checkPermissionsAndLaunchImagePicker()
+    private fun setClickEventThrottle() {
+        binding.imgbtnUpdateSpaceThumbnail.setClickEvent(lifecycleScope) {
+            imagePickerHandler.checkPermissionsAndLaunchImagePicker()
+        }
     }
 
     private fun collectSpaceEvent() {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/FlowExtension.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/FlowExtension.kt
@@ -1,9 +1,26 @@
 package boostcamp.and07.mindsync.ui.util
 
+import android.view.View
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 const val THROTTLE_DURATION = 200L
+
+fun View.setClickEvent(
+    uiScope: CoroutineScope,
+    windowDuration: Long = THROTTLE_DURATION,
+    onClick: () -> Unit,
+) {
+    clicks()
+        .throttleFirst(windowDuration)
+        .onEach { onClick.invoke() }
+        .launchIn(uiScope)
+}
 
 fun <T> Flow<T>.throttleFirst(windowDuration: Long = THROTTLE_DURATION): Flow<T> =
     flow {
@@ -15,4 +32,12 @@ fun <T> Flow<T>.throttleFirst(windowDuration: Long = THROTTLE_DURATION): Flow<T>
                 emit(upstream)
             }
         }
+    }
+
+fun View.clicks(): Flow<Unit> =
+    callbackFlow {
+        setOnClickListener {
+            this.trySend(Unit)
+        }
+        awaitClose { setOnClickListener(null) }
     }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/FlowExtension.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/FlowExtension.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-const val THROTTLE_DURATION = 200L
+const val THROTTLE_DURATION = 1000L
 
 fun View.setClickEvent(
     uiScope: CoroutineScope,

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/FlowExtension.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/FlowExtension.kt
@@ -1,0 +1,18 @@
+package boostcamp.and07.mindsync.ui.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+const val THROTTLE_DURATION = 200L
+
+fun <T> Flow<T>.throttleFirst(windowDuration: Long = THROTTLE_DURATION): Flow<T> =
+    flow {
+        var lastEmissionTime = 0L
+        collect { upstream ->
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - lastEmissionTime > windowDuration) {
+                lastEmissionTime = currentTime
+                emit(upstream)
+            }
+        }
+    }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/FlowExtension.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/util/FlowExtension.kt
@@ -9,11 +9,15 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-const val THROTTLE_DURATION = 1000L
+enum class ThrottleDuration(val duration: Long) {
+    SHORT_DURATION(250L),
+    MIDDLE_DURATION(500L),
+    LONG_DURATION(1000L),
+}
 
 fun View.setClickEvent(
     uiScope: CoroutineScope,
-    windowDuration: Long = THROTTLE_DURATION,
+    windowDuration: Long = ThrottleDuration.MIDDLE_DURATION.duration,
     onClick: () -> Unit,
 ) {
     clicks()
@@ -22,7 +26,7 @@ fun View.setClickEvent(
         .launchIn(uiScope)
 }
 
-fun <T> Flow<T>.throttleFirst(windowDuration: Long = THROTTLE_DURATION): Flow<T> =
+fun <T> Flow<T>.throttleFirst(windowDuration: Long = ThrottleDuration.MIDDLE_DURATION.duration): Flow<T> =
     flow {
         var lastEmissionTime = 0L
         collect { upstream ->

--- a/AOS/app/src/main/res/layout/activity_add_space.xml
+++ b/AOS/app/src/main/res/layout/activity_add_space.xml
@@ -8,10 +8,6 @@
         <variable
             name="vm"
             type="boostcamp.and07.mindsync.ui.space.generate.AddSpaceViewModel" />
-
-        <variable
-            name="view"
-            type="boostcamp.and07.mindsync.ui.space.generate.AddSpaceActivity" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -70,7 +66,6 @@
             android:layout_height="35dp"
             android:background="@drawable/ic_add"
             android:backgroundTint="@color/blue"
-            android:onClick="@{() -> view.clickImageButton()}"
             app:layout_constraintEnd_toEndOf="@id/iv_add_space_thumbnail"
             app:layout_constraintTop_toTopOf="@id/iv_add_space_thumbnail" />
 

--- a/AOS/app/src/main/res/layout/dialog_create_board.xml
+++ b/AOS/app/src/main/res/layout/dialog_create_board.xml
@@ -52,7 +52,6 @@
             android:layout_height="35dp"
             android:background="@drawable/ic_add"
             android:backgroundTint="@color/blue"
-            android:onClick="@{() -> view.clickImageButton()}"
             app:layout_constraintEnd_toEndOf="@id/iv_add_space_thumbnail"
             app:layout_constraintTop_toTopOf="@id/iv_add_space_thumbnail" />
 

--- a/AOS/app/src/main/res/layout/fragment_mind_map.xml
+++ b/AOS/app/src/main/res/layout/fragment_mind_map.xml
@@ -8,9 +8,6 @@
             name="vm"
             type="boostcamp.and07.mindsync.ui.mindmap.MindMapViewModel" />
         <import type="android.view.View"/>
-        <variable
-            name="view"
-            type="boostcamp.and07.mindsync.ui.mindmap.MindMapFragment" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -52,18 +49,17 @@
             android:layout_height="25dp"
             android:background="@android:color/transparent"
             android:src="@drawable/ic_add"
-            android:onClick="@{() -> view.addButtonListener(vm.selectedNode)}"
             app:layout_constraintBottom_toBottomOf="@id/view_mind_map_side_bar"
             app:layout_constraintEnd_toStartOf="@id/imgbtn_mind_map_remove"
             app:layout_constraintHorizontal_chainStyle="spread"
             app:layout_constraintStart_toStartOf="@id/view_mind_map_side_bar"
             app:layout_constraintTop_toTopOf="@id/view_mind_map_side_bar" />
+
         <ImageButton
             android:id="@+id/imgbtn_mind_map_remove"
             android:layout_width="25dp"
             android:layout_height="25dp"
             android:background="@drawable/btn_remove"
-            android:onClick="@{() -> vm.removeNode(vm.selectedNode)}"
             app:removeBtn="@{vm.selectedNode}"
             app:layout_constraintBottom_toBottomOf="@id/view_mind_map_side_bar"
             app:layout_constraintEnd_toStartOf="@id/imgbtn_mind_map_edit"
@@ -77,7 +73,6 @@
             android:layout_height="25dp"
             android:background="@android:color/transparent"
             android:src="@drawable/ic_outlined_drawing"
-            android:onClick="@{() -> view.editButtonListener(vm.selectedNode)}"
             app:layout_constraintBottom_toBottomOf="@id/view_mind_map_side_bar"
             app:layout_constraintEnd_toStartOf="@id/imgbtn_mind_map_back"
             app:layout_constraintHorizontal_chainStyle="spread"


### PR DESCRIPTION
## 관련 이슈
- #249 

## 작업한 내용
- throttle first extension 구현하기
- photo picker 를 여러번 클릭했을 때 throttle first로 한번만 창이 뜨도록 하기 (프로필 편집 화면, 보드 생성 화면, 스페이스 생성 화면)
- MindMapFragment에서의 버튼 클릭에 throttle first 적용하기 (노드 추가, 편집, 삭제)
- MainActivity의 Sidebar에서의 버튼들도 여러번 눌러도 한번만 적용되게 하기
- 보드 추가 버튼을 여러번 눌러도 창이 한번만 뜨도록 하기
- before

  https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/9bf3e85d-abb9-4b1c-881f-97ef31d6e733

- after

  https://github.com/boostcampwm2023/and07-MindSync/assets/75965560/faa34e23-124b-43cd-8aa5-9ba4c543cca3

- Invite Code를 얻어왔을 때 Toast로 "성공!" 뜨는 부분 제거