### PR TITLE
보드 새로고침 버튼 추가

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListFragment.kt
@@ -88,5 +88,8 @@ class BoardListFragment :
                 boardListViewModel.deleteBoard()
             }
         }
+        binding.btnBoardListRefresh.setClickEvent(lifecycleScope) {
+            boardListViewModel.getBoards()
+        }
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListViewModel.kt
@@ -60,11 +60,11 @@ class BoardListViewModel
             }
         }
 
-        private fun getBoards() {
+        fun getBoards() {
             viewModelScope.launch(coroutineExceptionHandler) {
-                boardListRepository.getBoard(_boardUiState.value.spaceId).collectLatest { list ->
-                    _boardUiState.update { it ->
-                        it.copy(boards = list)
+                boardListRepository.getBoard(_boardUiState.value.spaceId).collectLatest { boards ->
+                    _boardUiState.update { boardUiState ->
+                        boardUiState.copy(boards = boards)
                     }
                     _boardUiEvent.emit(BoardUiEvent.Success)
                 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainActivity.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainActivity.kt
@@ -183,6 +183,7 @@ class MainActivity :
         spaceAdapter.setSideBarClickListener(
             object : SpaceClickListener {
                 override fun onClickSpace(space: Space) {
+                    navController.navigate(SpaceListFragmentDirections.actionToBoardListFragment(spaceId = space.id))
                     mainViewModel.updateCurrentSpace(space)
                 }
             },

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainViewModel.kt
@@ -29,6 +29,7 @@ class MainViewModel
         val uiState: StateFlow<MainUiState> = _uiState
         private val _event = MutableSharedFlow<MainUiEvent>()
         val event: SharedFlow<MainUiEvent> = _event
+
         private val coroutineExceptionHandler =
             CoroutineExceptionHandler { _, throwable ->
                 viewModelScope.launch { _event.emit(MainUiEvent.ShowMessage(throwable.message.toString())) }

--- a/AOS/app/src/main/res/layout/fragment_board_list.xml
+++ b/AOS/app/src/main/res/layout/fragment_board_list.xml
@@ -30,14 +30,25 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_gravity="center|top"
-            app:boards="@{vm.boardUiState.boards}"
             android:background="@android:color/transparent"
+            app:boards="@{vm.boardUiState.boards}"
             app:flexBoxLayoutManager="@{FlexDirection.ROW}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/gl_board_list_end"
             app:layout_constraintStart_toEndOf="@id/gl_board_list_start"
             app:layout_constraintTop_toTopOf="parent"
             tools:listitem="@layout/item_board" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/btn_board_list_refresh"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_restore_board"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:rippleColor="@color/mindmap2" />
 
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton


### PR DESCRIPTION
## 관련 이슈
- #269 
## 작업한 내용
### 보드 새로고침 기능 추가

![image](https://github.com/boostcampwm2023/and07-MindSync/assets/99114456/a05e9c62-6fd6-4562-b0c8-a5cd2bd35d17)
- Ui에 버튼 추가

[board 새로고침.webm](https://github.com/boostcampwm2023/and07-MindSync/assets/99114456/6625a647-858c-4c81-9ec8-03f986712e0c)
- 새로고침 기능 추가

사이드바에서 스페이스 클릭할 경우 화면이 그대로여서 일단 스페이스에 해당하는 보드리스트로 옮겨놨는데 어떤화면으로 해야할지 좀 정해야할거같아요 아예 스페이스 리스트로 간다거나? 지금은 보드리스트인데 다른의견있나용??
1. 스페이스 목록
2. 보드 목록