### PR TITLE
Board 삭제,목록불러오기 수정

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepositoryImpl.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepositoryImpl.kt
@@ -42,7 +42,7 @@ class BoardListRepositoryImpl
             flow {
                 val response = boardApi.getBoards(spaceId)
                 emit(
-                    response.data.map { board ->
+                    response.data.filter { board -> board.isDeleted.not() }.map { board ->
                         Board(
                             id = board.boardId,
                             name = board.boardName,

--- a/AOS/app/src/main/res/layout/item_board.xml
+++ b/AOS/app/src/main/res/layout/item_board.xml
@@ -17,7 +17,7 @@
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cv_board_thumbnail"
-            android:layout_width="120dp"
+            android:layout_width="100dp"
             android:layout_height="100dp"
             app:layout_constraintStart_toEndOf="@id/cb_board"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
## 관련 이슈
- #274 
## 작업한 내용
- 보드 불러오기 수정
- 보드삭제는 완전한 삭제가 아닌 임시 삭제라 isDeleted로 get에서 걸러줘야했음.

```kotlin
 flow {
                val response = boardApi.getBoards(spaceId)
                emit(
                    response.data.filter { board -> board.isDeleted.not() }.map { board ->
                        Board(
                            id = board.boardId,
                            name = board.boardName,
                            date = board.createdAt,
                            imageUrl = board.imageUrl,
                        )
                    },
                )
            }
```