### PR TITLE
휴지통 화면, 보드 복구 API, 루트노드 일치화

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/network/BoardApi.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/network/BoardApi.kt
@@ -1,9 +1,11 @@
 package boostcamp.and07.mindsync.data.network
 
 import boostcamp.and07.mindsync.data.network.request.board.DeleteBoardRequest
+import boostcamp.and07.mindsync.data.network.request.board.RestoreBoardRequest
 import boostcamp.and07.mindsync.data.network.response.board.BoardsResponse
 import boostcamp.and07.mindsync.data.network.response.board.CreateBoardResponse
 import boostcamp.and07.mindsync.data.network.response.board.DeleteBoardResponse
+import boostcamp.and07.mindsync.data.network.response.board.RestoreBoardResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Body
@@ -32,4 +34,9 @@ interface BoardApi {
     suspend fun deleteBoard(
         @Body deleteBoardRequest: DeleteBoardRequest,
     ): DeleteBoardResponse
+
+    @PATCH("boards/restore")
+    suspend fun restoreBoard(
+        @Body restoreRequest: RestoreBoardRequest,
+    ): RestoreBoardResponse
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/network/request/board/RestoreBoardRequest.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/network/request/board/RestoreBoardRequest.kt
@@ -1,0 +1,8 @@
+package boostcamp.and07.mindsync.data.network.request.board
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RestoreBoardRequest(
+    val boardId: String,
+)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/network/response/board/RestoreBoardResponse.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/network/response/board/RestoreBoardResponse.kt
@@ -1,0 +1,10 @@
+package boostcamp.and07.mindsync.data.network.response.board
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RestoreBoardResponse(
+    val statusCode: Int,
+    val message: String,
+    val error: String? = null,
+)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepository.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepository.kt
@@ -14,4 +14,6 @@ interface BoardListRepository {
     fun getBoard(spaceId: String): Flow<List<Board>>
 
     fun deleteBoard(boardId: String): Flow<Boolean>
+
+    fun restoreBoard(boardId: String): Flow<Boolean>
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepository.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepository.kt
@@ -11,7 +11,10 @@ interface BoardListRepository {
         imageUrl: MultipartBody.Part?,
     ): Flow<Board>
 
-    fun getBoard(spaceId: String): Flow<List<Board>>
+    fun getBoard(
+        spaceId: String,
+        isDeleted: Boolean,
+    ): Flow<List<Board>>
 
     fun deleteBoard(boardId: String): Flow<Boolean>
 

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepositoryImpl.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepositoryImpl.kt
@@ -39,11 +39,14 @@ class BoardListRepositoryImpl
                 }
             }
 
-        override fun getBoard(spaceId: String): Flow<List<Board>> =
+        override fun getBoard(
+            spaceId: String,
+            isDeleted: Boolean,
+        ): Flow<List<Board>> =
             flow {
                 val response = boardApi.getBoards(spaceId)
                 emit(
-                    response.data.filter { board -> board.isDeleted.not() }.map { board ->
+                    response.data.filter { board -> board.isDeleted == isDeleted }.map { board ->
                         Board(
                             id = board.boardId,
                             name = board.boardName,

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepositoryImpl.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/data/repository/boardlist/BoardListRepositoryImpl.kt
@@ -3,6 +3,7 @@ package boostcamp.and07.mindsync.data.repository.boardlist
 import boostcamp.and07.mindsync.data.model.Board
 import boostcamp.and07.mindsync.data.network.BoardApi
 import boostcamp.and07.mindsync.data.network.request.board.DeleteBoardRequest
+import boostcamp.and07.mindsync.data.network.request.board.RestoreBoardRequest
 import boostcamp.and07.mindsync.ui.util.toRequestBody
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -56,6 +57,12 @@ class BoardListRepositoryImpl
         override fun deleteBoard(boardId: String): Flow<Boolean> =
             flow {
                 val response = boardApi.deleteBoard(DeleteBoardRequest(boardId))
+                emit(true)
+            }
+
+        override fun restoreBoard(boardId: String): Flow<Boolean> =
+            flow {
+                val response = boardApi.restoreBoard(RestoreBoardRequest(boardId))
                 emit(true)
             }
     }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListAdapter.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListAdapter.kt
@@ -64,7 +64,7 @@ class BoardListAdapter : ListAdapter<Board, BoardListAdapter.BoardListViewHolder
                     oldItem: Board,
                     newItem: Board,
                 ): Boolean {
-                    return oldItem.id == newItem.id
+                    return oldItem == newItem
                 }
             }
     }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/boardlist/BoardListViewModel.kt
@@ -62,7 +62,7 @@ class BoardListViewModel
 
         fun getBoards() {
             viewModelScope.launch(coroutineExceptionHandler) {
-                boardListRepository.getBoard(_boardUiState.value.spaceId).collectLatest { boards ->
+                boardListRepository.getBoard(_boardUiState.value.spaceId, false).collectLatest { boards ->
                     _boardUiState.update { boardUiState ->
                         boardUiState.copy(boards = boards)
                     }
@@ -87,6 +87,25 @@ class BoardListViewModel
                 val newSelectBoards = boardUiState.value.selectBoards.toMutableList()
                 _boardUiState.value.selectBoards.map { board ->
                     boardListRepository.deleteBoard(board.id).collectLatest {
+                        newBoards.remove(board)
+                        newSelectBoards.remove(board)
+                    }
+                }
+                _boardUiState.update { boardUiState ->
+                    boardUiState.copy(
+                        boards = newBoards,
+                        selectBoards = newSelectBoards,
+                    )
+                }
+            }
+        }
+
+        fun restoreBoard() {
+            viewModelScope.launch(coroutineExceptionHandler) {
+                val newBoards = boardUiState.value.boards.toMutableList()
+                val newSelectBoards = boardUiState.value.selectBoards.toMutableList()
+                _boardUiState.value.selectBoards.map { board ->
+                    boardListRepository.restoreBoard(board.id).collectLatest {
                         newBoards.remove(board)
                         newSelectBoards.remove(board)
                     }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainActivity.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/main/MainActivity.kt
@@ -118,7 +118,20 @@ class MainActivity :
                 ThrottleDuration.LONG_DURATION.duration,
             ) {
                 drawerLayout.closeDrawers()
-                navController.navigate(R.id.action_to_recycleBinFragment)
+                mainViewModel.uiState.value.nowSpace?.let { nowSpace ->
+                    drawerLayout.closeDrawers()
+                    navController.navigate(
+                        SpaceListFragmentDirections.actionToRecycleBinFragment(
+                            spaceId = nowSpace.id,
+                        ),
+                    )
+                } ?: run {
+                    Toast.makeText(
+                        this@MainActivity,
+                        resources.getString(R.string.space_not_join),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                }
             }
 
             imgbtnSideBarAddSpace.setClickEvent(
@@ -228,6 +241,7 @@ class MainActivity :
                             uiState.spaces.isEmpty() -> getString(R.string.app_start)
                             destination.id == R.id.spaceListFragment -> getString(R.string.space_list_title)
                             destination.id == R.id.boardListFragment -> getString(R.string.board_list_title)
+                            destination.id == R.id.recycleBinFragment -> getString(R.string.recyclebin_title)
                             else -> ""
                         }
                 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -36,7 +36,7 @@ class MindMapViewModel
         private val mindMapRepository: MindMapRepository,
     ) : ViewModel() {
         private var boardId: String = ""
-        val crdtTree = CrdtTree(IdGenerator.makeRandomNodeId())
+        val crdtTree = CrdtTree(id = IdGenerator.makeRandomNodeId(), tree = Tree())
         private var _selectedNode = MutableStateFlow<Node?>(null)
         val selectedNode: StateFlow<Node?> = _selectedNode
         private val _operation = MutableStateFlow<Operation?>(null)
@@ -52,7 +52,7 @@ class MindMapViewModel
             setSocketEvent()
         }
 
-        fun setBoardId(boardId: String) {
+        fun setBoard(boardId: String, boardName: String) {
             if (this.boardId != boardId) {
                 this.boardId = boardId
                 joinBoard(boardId, boardName)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -59,6 +59,7 @@ class MindMapViewModel
             if (this.boardId != boardId) {
                 this.boardId = boardId
                 joinBoard(boardId, boardName)
+                updateNode(crdtTree.tree.getRootNode().copy(description = boardName))
             }
         }
 

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -52,7 +52,10 @@ class MindMapViewModel
             setSocketEvent()
         }
 
-        fun setBoard(boardId: String, boardName: String) {
+        fun setBoard(
+            boardId: String,
+            boardName: String,
+        ) {
             if (this.boardId != boardId) {
                 this.boardId = boardId
                 joinBoard(boardId, boardName)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinFragment.kt
@@ -1,10 +1,52 @@
 package boostcamp.and07.mindsync.ui.recyclebin
 
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import boostcamp.and07.mindsync.R
+import boostcamp.and07.mindsync.data.model.Board
 import boostcamp.and07.mindsync.databinding.FragmentRecycleBinBinding
 import boostcamp.and07.mindsync.ui.base.BaseFragment
+import boostcamp.and07.mindsync.ui.boardlist.BoardClickListener
+import boostcamp.and07.mindsync.ui.boardlist.BoardListAdapter
+import boostcamp.and07.mindsync.ui.boardlist.BoardListFragmentDirections
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class RecycleBinFragment : BaseFragment<FragmentRecycleBinBinding>(R.layout.fragment_recycle_bin) {
+    private val recycleBinViewModel: RecycleBinViewModel by viewModels()
+    private val boardListAdapter = BoardListAdapter()
+    private val args: RecycleBinFragmentArgs by navArgs()
+
     override fun initView() {
+        setBinding()
+        setBoardRestoreButton()
+        recycleBinViewModel.setSpace(args.spaceId)
+    }
+
+    private fun setBinding() {
+        binding.vm = recycleBinViewModel
+        binding.rvRecyclebinBoard.adapter = boardListAdapter
+        boardListAdapter.setBoardClickListener(
+            object : BoardClickListener {
+                override fun onClick(board: Board) {
+                    findNavController().navigate(
+                        BoardListFragmentDirections.actionBoardListFragmentToMindMapFragment(
+                            board.id,
+                        ),
+                    )
+                }
+
+                override fun onCheckBoxClick(board: Board) {
+                    recycleBinViewModel.selectBoard(board)
+                }
+            },
+        )
+    }
+
+    private fun setBoardRestoreButton() {
+        binding.btnRecyclebinRestore.setOnClickListener {
+            recycleBinViewModel.restoreBoard()
+        }
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinFragment.kt
@@ -32,7 +32,8 @@ class RecycleBinFragment : BaseFragment<FragmentRecycleBinBinding>(R.layout.frag
                 override fun onClick(board: Board) {
                     findNavController().navigate(
                         BoardListFragmentDirections.actionBoardListFragmentToMindMapFragment(
-                            board.id,
+                            boardId = board.id,
+                            boardName = board.name,
                         ),
                     )
                 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinUiEvent.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinUiEvent.kt
@@ -1,0 +1,7 @@
+package boostcamp.and07.mindsync.ui.recyclebin
+
+sealed class RecycleBinUiEvent {
+    data object Success : RecycleBinUiEvent()
+
+    data class Error(val message: String) : RecycleBinUiEvent()
+}

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinUiState.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinUiState.kt
@@ -1,0 +1,9 @@
+package boostcamp.and07.mindsync.ui.recyclebin
+
+import boostcamp.and07.mindsync.data.model.Board
+
+data class RecycleBinUiState(
+    val spaceId: String = "",
+    val boards: List<Board> = listOf(),
+    val selectBoards: List<Board> = listOf(),
+)

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/recyclebin/RecycleBinViewModel.kt
@@ -1,0 +1,84 @@
+package boostcamp.and07.mindsync.ui.recyclebin
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import boostcamp.and07.mindsync.data.model.Board
+import boostcamp.and07.mindsync.data.repository.boardlist.BoardListRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RecycleBinViewModel
+    @Inject
+    constructor(
+        private val boardListRepository: BoardListRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(RecycleBinUiState())
+        val uiState: StateFlow<RecycleBinUiState> = _uiState
+        private val _uiEvent = MutableSharedFlow<RecycleBinUiEvent>()
+        val uiEvent: SharedFlow<RecycleBinUiEvent> = _uiEvent
+
+        private val coroutineExceptionHandler =
+            CoroutineExceptionHandler { _, throwable ->
+                viewModelScope.launch {
+                    _uiEvent.emit(RecycleBinUiEvent.Error(throwable.message.toString()))
+                }
+            }
+
+        fun setSpace(spaceId: String) {
+            _uiState.update { boardUiState ->
+                boardUiState.copy(
+                    spaceId = spaceId,
+                )
+            }
+            getBoards()
+        }
+
+        fun getBoards() {
+            viewModelScope.launch(coroutineExceptionHandler) {
+                boardListRepository.getBoard(_uiState.value.spaceId, true).collectLatest { boards ->
+                    _uiState.update { boardUiState ->
+                        boardUiState.copy(boards = boards)
+                    }
+                    _uiEvent.emit(RecycleBinUiEvent.Success)
+                }
+            }
+        }
+
+        fun selectBoard(selectBoard: Board) {
+            _uiState.update { boardUiState ->
+                val newSelectBoards =
+                    boardUiState.boards.toMutableList().filter { board -> board.isChecked }
+                boardUiState.copy(
+                    selectBoards = newSelectBoards,
+                )
+            }
+        }
+
+        fun restoreBoard() {
+            viewModelScope.launch(coroutineExceptionHandler) {
+                val newBoards = uiState.value.boards.toMutableList()
+                val newSelectBoards = uiState.value.selectBoards.toMutableList()
+                _uiState.value.selectBoards.map { board ->
+                    boardListRepository.restoreBoard(board.id).collectLatest {
+                        newBoards.remove(board)
+                        newSelectBoards.remove(board)
+                    }
+                }
+                _uiState.update { boardUiState ->
+                    boardUiState.copy(
+                        boards = newBoards,
+                        selectBoards = newSelectBoards,
+                    )
+                }
+            }
+        }
+    }

--- a/AOS/app/src/main/res/drawable/ic_refresh_board.xml
+++ b/AOS/app/src/main/res/drawable/ic_refresh_board.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/AOS/app/src/main/res/layout/fragment_board_list.xml
+++ b/AOS/app/src/main/res/layout/fragment_board_list.xml
@@ -45,7 +45,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="10dp"
             android:background="@android:color/transparent"
-            android:src="@drawable/ic_restore_board"
+            android:src="@drawable/ic_refresh_board"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:rippleColor="@color/mindmap2" />

--- a/AOS/app/src/main/res/layout/fragment_recycle_bin.xml
+++ b/AOS/app/src/main/res/layout/fragment_recycle_bin.xml
@@ -4,7 +4,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <variable
+            name="vm"
+            type="boostcamp.and07.mindsync.ui.recyclebin.RecycleBinViewModel" />
 
+        <import type="com.google.android.flexbox.FlexDirection"></import>
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -12,14 +16,58 @@
         android:layout_height="match_parent"
         tools:context=".ui.recyclebin.RecycleBinFragment">
 
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_recyclebin_start"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.1" />
+
+
         <TextView
+            android:id="@+id/tv_recyclebin_info"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            app:layout_constraintStart_toStartOf="@id/gl_recyclebin_start"
+            app:layout_constraintTop_toTopOf="parent"
+            style="@style/Typography.Body01.Medium"
+            app:layout_constraintEnd_toEndOf="@id/gl_recyclebin_end"
+            android:text="@string/recyclebin_info"
+            android:background="@color/gray3"
+            />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_recyclebin_board"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_gravity="center|top"
+            android:layout_marginTop="15dp"
+            android:background="@android:color/transparent"
+            app:boards="@{vm.uiState.boards}"
+            app:flexBoxLayoutManager="@{FlexDirection.ROW}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/gl_recyclebin_end"
+            app:layout_constraintStart_toEndOf="@id/gl_recyclebin_start"
+            app:layout_constraintTop_toBottomOf="@id/tv_recyclebin_info"
+            tools:listitem="@layout/item_recycle_board" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/btn_recyclebin_restore"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Recycle Bin Fragment"
+            android:layout_margin="10dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_restore_board"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:rippleColor="@color/mindmap2" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/gl_recyclebin_end"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.9" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/AOS/app/src/main/res/layout/item_recycle_board.xml
+++ b/AOS/app/src/main/res/layout/item_recycle_board.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="board"
+            type="boostcamp.and07.mindsync.data.model.Board" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="5dp">
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_recyclebin_board_thumbnail"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_constraintStart_toEndOf="@id/cb_board"
+            app:layout_constraintTop_toTopOf="parent"
+            >
+
+            <ImageButton
+                android:id="@+id/imgbtn_recyclebin_board_item"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@null"
+                android:scaleType="centerCrop"
+                app:boardImageUri="@{board.imageUrl}"
+                android:src="@mipmap/ic_app_logo" />
+        </androidx.cardview.widget.CardView>
+
+        <CheckBox
+            android:id="@+id/cb_board"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            />
+
+        <TextView
+            android:id="@+id/tv_recyclebin_board_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/board_list_board_name"
+            android:fontFamily="@font/pretendard_bold"
+            android:text="@{board.name}"
+            android:textAlignment="center"
+            app:layout_constraintEnd_toEndOf="@id/cv_recyclebin_board_thumbnail"
+            app:layout_constraintStart_toStartOf="@id/cv_recyclebin_board_thumbnail"
+            app:layout_constraintTop_toBottomOf="@id/cv_recyclebin_board_thumbnail"
+            tools:text="@string/board_list_board_name" />
+
+        <TextView
+            android:id="@+id/tv_recyclebin_board_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/board_list_board_create_date"
+            android:fontFamily="@font/pretendard_bold"
+            app:date="@{board.date}"
+            app:layout_constraintEnd_toEndOf="@id/cv_recyclebin_board_thumbnail"
+            app:layout_constraintStart_toStartOf="@id/cv_recyclebin_board_thumbnail"
+            app:layout_constraintTop_toBottomOf="@id/tv_recyclebin_board_title"
+            tools:text="@string/board_list_board_create_date" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/AOS/app/src/main/res/navigation/nav_graph.xml
+++ b/AOS/app/src/main/res/navigation/nav_graph.xml
@@ -33,7 +33,11 @@
     <fragment
         android:id="@+id/recycleBinFragment"
         android:name="boostcamp.and07.mindsync.ui.recyclebin.RecycleBinFragment"
-        android:label="RecycleBinFragment" />
+        android:label="RecycleBinFragment">
+        <argument
+            android:name="spaceId"
+            app:argType="string" />
+    </fragment>
     <activity
         android:id="@+id/addSpaceActivity"
         android:name="boostcamp.and07.mindsync.ui.space.generate.AddSpaceActivity"

--- a/AOS/app/src/main/res/values/strings-board.xml
+++ b/AOS/app/src/main/res/values/strings-board.xml
@@ -4,4 +4,6 @@
     <string name="board_list_board_create_date">yyyy-mm-dd</string>
     <string name="board_multipart_image_name">image</string>
     <string name="board_list_title">보드 목록</string>
+    <string name="recyclebin_title">휴지통</string>
+    <string name="recyclebin_info">휴지통의 보드는 7일 후에 자동 삭제 됩니다.</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- #247 
- #279 
- #280 
- #272
## 작업한 내용
- 휴지통 화면
- 보드 복구

[보드복구.webm](https://github.com/boostcampwm2023/and07-MindSync/assets/99114456/357b3532-0a7c-48ac-b3f0-eeb9ef9a51d6)

- 루트노드 보드이름과 일치화

[루트노드이름.webm](https://github.com/boostcampwm2023/and07-MindSync/assets/99114456/db580ec2-1221-4e53-9197-a6d612d87b82)

- 보드 새로고침 아이콘 변경