### PR TITLE
사이드바 유저목록 디자인 수정

### DIFF
--- a/AOS/app/src/main/res/layout/item_users.xml
+++ b/AOS/app/src/main/res/layout/item_users.xml
@@ -13,12 +13,13 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="5dp">
+        android:padding="10dp"
+        >
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cv_side_bar_user_profile"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
             android:backgroundTint="@color/gray4"
             app:cardCornerRadius="20dp"
             app:layout_constraintEnd_toEndOf="parent"
@@ -41,7 +42,7 @@
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:fontFamily="@font/pretendard_bold"
-            android:singleLine="true"
+            android:maxLines="2"
             android:text="@{user.nickname}"
             android:textAlignment="center"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## 관련 이슈
- #296 
## 작업한 내용
![image](https://github.com/boostcampwm2023/and07-MindSync/assets/99114456/b8bf5855-f40b-46d3-a55a-d6156ebd0ff3)
- 이미지 크기 조절 및 패딩 조절
- maxLine 2로 지정