### PR TITLE
MindMapViewModel을 navGraphViewModels로 사용하게 되는 문제 해결

### DIFF
--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/EditDescriptionDialog.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/EditDescriptionDialog.kt
@@ -14,7 +14,7 @@ import androidx.fragment.app.viewModels
 import boostcamp.and07.mindsync.R
 import boostcamp.and07.mindsync.databinding.DialogEditDescriptionBinding
 
-class EditDescriptionDialog() : DialogFragment() {
+class EditDescriptionDialog : DialogFragment() {
     private var _binding: DialogEditDescriptionBinding? = null
     private val binding get() = _binding!!
     private val editDescriptionViewModel: EditDescriptionViewModel by viewModels()

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/EditDescriptionViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/EditDescriptionViewModel.kt
@@ -1,0 +1,19 @@
+package boostcamp.and07.mindsync.ui.dialog
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class EditDescriptionViewModel : ViewModel() {
+    private val _description = MutableStateFlow("")
+    val description: StateFlow<String> = _description
+    var submitListener: ((String) -> (Unit))? = null
+
+    fun setDescription(text: String) {
+        _description.value = text
+    }
+
+    fun onDescriptionChanged(inputDescription: CharSequence) {
+        _description.value = inputDescription.toString()
+    }
+}

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/EditDialogInterface.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/EditDialogInterface.kt
@@ -1,5 +1,0 @@
-package boostcamp.and07.mindsync.ui.dialog
-
-interface EditDialogInterface {
-    fun onSubmitClick(description: String)
-}

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/EditNickNameInterface.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/dialog/EditNickNameInterface.kt
@@ -1,5 +1,0 @@
-package boostcamp.and07.mindsync.ui.dialog
-
-interface EditNickNameInterface {
-    fun onModifyClick(nickname: String)
-}

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
@@ -92,9 +92,9 @@ class MindMapFragment :
         operationType: OperationType,
         selectedNode: Node,
     ) {
-        val text: String = if (operationType == OperationType.ADD) "" else selectedNode.description
+        val description = if (operationType == OperationType.ADD) "" else selectedNode.description
         val editDescriptionDialog = EditDescriptionDialog()
-        editDescriptionDialog.setDescription(text)
+        editDescriptionDialog.setDescription(description)
         editDescriptionDialog.setSubmitListener { description ->
             when (operationType) {
                 OperationType.ADD -> {

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapFragment.kt
@@ -1,19 +1,20 @@
 package boostcamp.and07.mindsync.ui.mindmap
 
-import android.content.Context
-import androidx.activity.OnBackPressedCallback
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import androidx.navigation.navGraphViewModels
 import boostcamp.and07.mindsync.R
 import boostcamp.and07.mindsync.data.crdt.OperationType
+import boostcamp.and07.mindsync.data.model.CircleNode
 import boostcamp.and07.mindsync.data.model.Node
+import boostcamp.and07.mindsync.data.model.RectangleNode
 import boostcamp.and07.mindsync.data.model.Tree
+import boostcamp.and07.mindsync.data.util.NodeGenerator
 import boostcamp.and07.mindsync.databinding.FragmentMindMapBinding
 import boostcamp.and07.mindsync.ui.base.BaseFragment
+import boostcamp.and07.mindsync.ui.dialog.EditDescriptionDialog
 import boostcamp.and07.mindsync.ui.util.Dp
 import boostcamp.and07.mindsync.ui.util.Px
 import boostcamp.and07.mindsync.ui.util.ThrottleDuration
@@ -33,24 +34,9 @@ class MindMapFragment :
     NodeClickListener,
     TreeUpdateListener,
     NodeMoveListener {
-    private val mindMapViewModel: MindMapViewModel by navGraphViewModels(R.id.nav_graph) {
-        MindMapViewModelFactory()
-    }
+    private val mindMapViewModel: MindMapViewModel by viewModels()
     private lateinit var mindMapContainer: MindMapContainer
     private val args: MindMapFragmentArgs by navArgs()
-    private var isBack = false
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        val callback =
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    isBack = true
-                    findNavController().popBackStack()
-                }
-            }
-        requireActivity().onBackPressedDispatcher.addCallback(this, callback)
-    }
 
     override fun initView() {
         setupRootNode()
@@ -64,10 +50,12 @@ class MindMapFragment :
     private fun collectOperation() {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                mindMapViewModel.operation.collectLatest {
-                    mindMapContainer.update(mindMapViewModel.crdtTree.tree)
-                    binding.zoomLayoutMindMapRoot.lineView.updateTree(mindMapContainer.tree)
-                    binding.zoomLayoutMindMapRoot.nodeView.updateTree(mindMapContainer.tree)
+                mindMapViewModel.operation.collectLatest { operation ->
+                    operation?.let {
+                        mindMapContainer.update(mindMapViewModel.crdtTree.tree)
+                        binding.zoomLayoutMindMapRoot.lineView.updateTree(mindMapContainer.tree)
+                        binding.zoomLayoutMindMapRoot.nodeView.updateTree(mindMapContainer.tree)
+                    }
                 }
             }
         }
@@ -104,11 +92,30 @@ class MindMapFragment :
         operationType: OperationType,
         selectedNode: Node,
     ) {
-        findNavController().navigate(
-            MindMapFragmentDirections.actionMindMapFragmentToEditDescriptionDialog(
-                operationType,
-                selectedNode,
-            ),
+        val text: String = if (operationType == OperationType.ADD) "" else selectedNode.description
+        val editDescriptionDialog = EditDescriptionDialog()
+        editDescriptionDialog.setDescription(text)
+        editDescriptionDialog.setSubmitListener { description ->
+            when (operationType) {
+                OperationType.ADD -> {
+                    mindMapViewModel.addNode(selectedNode, NodeGenerator.makeNode(description, selectedNode.id))
+                }
+
+                OperationType.UPDATE -> {
+                    val newNode =
+                        when (selectedNode) {
+                            is CircleNode -> selectedNode.copy(description = description)
+                            is RectangleNode -> selectedNode.copy(description = description)
+                        }
+                    mindMapViewModel.updateNode(newNode)
+                }
+
+                else -> {}
+            }
+        }
+        editDescriptionDialog.show(
+            requireActivity().supportFragmentManager,
+            "EditDescriptionDialog",
         )
     }
 
@@ -155,12 +162,5 @@ class MindMapFragment :
         parent: Node,
     ) {
         mindMapViewModel.moveNode(tree, target, parent)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        if (isBack) {
-            mindMapViewModel.clearTree()
-        }
     }
 }

--- a/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
+++ b/AOS/app/src/main/java/boostcamp/and07/mindsync/ui/mindmap/MindMapViewModel.kt
@@ -43,8 +43,6 @@ class MindMapViewModel
         val socketState: StateFlow<SocketState> = _socketState
         private val _socketEvent = MutableStateFlow<SocketEvent?>(null)
         val socketEvent: StateFlow<SocketEvent?> = _socketEvent
-        private val _operationType = MutableStateFlow("")
-        val operationType: StateFlow<String> = _operationType
 
         init {
             setSocketState()
@@ -217,19 +215,5 @@ class MindMapViewModel
                         ),
                 ),
             )
-        }
-
-        fun updateOperationType(operationType: String) {
-            _operationType.value = operationType
-        }
-
-        fun clearTree() {
-            boardId = ""
-            crdtTree =
-                CrdtTree(
-                    id = "",
-                    tree = Tree(),
-                )
-            _selectedNode.value = null
         }
     }

--- a/AOS/app/src/main/res/layout/dialog_edit_description.xml
+++ b/AOS/app/src/main/res/layout/dialog_edit_description.xml
@@ -5,7 +5,7 @@
     <data>
         <variable
             name="vm"
-            type="boostcamp.and07.mindsync.ui.mindmap.MindMapViewModel" />
+            type="boostcamp.and07.mindsync.ui.dialog.EditDescriptionViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -14,13 +14,13 @@
         android:padding="10dp"
         android:layout_height="300dp">
 
-
         <EditText
             android:id="@+id/et_node_description"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:hint="@string/mindmap_input_text"
-            android:text="@{vm.operationType.equals(@string/mindmap_add) ? @string/mindmap_text_empty : vm.selectedNode.description}"
+            android:onTextChanged="@{(p0, p1, p2, p3) -> vm.onDescriptionChanged(p0)}"
+            android:text="@{vm.description}"
             android:textAlignment="center"
             android:fontFamily="@font/pretendard_regular"
             app:layout_constraintBottom_toTopOf="@id/btn_submit"

--- a/AOS/app/src/main/res/layout/dialog_edit_description.xml
+++ b/AOS/app/src/main/res/layout/dialog_edit_description.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <variable
             name="vm"
             type="boostcamp.and07.mindsync.ui.dialog.EditDescriptionViewModel" />
@@ -10,19 +11,19 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="300dp"
+        android:layout_height="300dp"
         android:background="@drawable/bg_round_dialog"
-        android:padding="10dp"
-        android:layout_height="300dp">
+        android:padding="10dp">
 
         <EditText
             android:id="@+id/et_node_description"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:fontFamily="@font/pretendard_regular"
             android:hint="@string/mindmap_input_text"
             android:onTextChanged="@{(p0, p1, p2, p3) -> vm.onDescriptionChanged(p0)}"
             android:text="@{vm.description}"
             android:textAlignment="center"
-            android:fontFamily="@font/pretendard_regular"
             app:layout_constraintBottom_toTopOf="@id/btn_submit"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -30,20 +31,22 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_cancel"
+            style="@style/Typography.Body02.Medium"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/cancel_message"
+            android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/btn_submit"
-            android:fontFamily="@font/pretendard_medium"
             app:layout_constraintStart_toStartOf="parent" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_submit"
+            style="@style/Typography.Body02.Medium"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/mindmap_write"
-            android:fontFamily="@font/pretendard_medium"
+            android:textColor="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/btn_cancel" />


### PR DESCRIPTION
## 관련 이슈
- #309 

## 작업한 내용
- EditDescriptionDialog 에서 회전시 앱이 죽는 문제를 해결하기 위해 navGraphViewModels 로 MindMapViewModel을 주입받아 쓰도록 했었음
- 그런데 navGraphViewModels을 쓰니 MindMapViewModel이 MindMapFragment의 생명주기를 따르지 않는 문제가 생겻음
- MindMapFragment가 detached 되어도 MindMapViewModel이 없어지지 않아서 CRDT Tree가 각 보드에 겹쳐서 존재하는 문제가 있었음
- => EditDescriptionDialog에서 콜백 패턴을 이용해 mindMapViewModel 없이 일반 뷰모델로 사용할 수 있도록 변경함