### PR TITLE
User 모델 분리

### DIFF
--- a/nestjs-BE/server/prisma/migrations/20240923070500_split_user_schema/migration.sql
+++ b/nestjs-BE/server/prisma/migrations/20240923070500_split_user_schema/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE `KakaoUser` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `email` VARCHAR(191) NOT NULL,
+    `userUuid` VARCHAR(191) NOT NULL,
+
+    UNIQUE INDEX `KakaoUser_email_key`(`email`),
+    UNIQUE INDEX `KakaoUser_userUuid_key`(`userUuid`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `KakaoUser` ADD CONSTRAINT `KakaoUser_userUuid_fkey` FOREIGN KEY (`userUuid`) REFERENCES `User`(`uuid`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- InsertData
+INSERT INTO `KakaoUser` (`email`, `userUuid`) SELECT `email`, `uuid` FROM `User` WHERE `provider` = 'kakao';
+
+-- DropIndex
+DROP INDEX `User_email_provider_key` ON `User`;
+
+-- AlterTable
+ALTER TABLE `User` DROP COLUMN `email`,
+    DROP COLUMN `provider`;
+
+-- AlterTable
+ALTER TABLE `User` MODIFY `uuid` varchar(36);

--- a/nestjs-BE/server/prisma/migrations/20240924021857_fix_profile_attribute/migration.sql
+++ b/nestjs-BE/server/prisma/migrations/20240924021857_fix_profile_attribute/migration.sql
@@ -1,0 +1,13 @@
+-- RenameColumn
+ALTER TABLE `Profile` RENAME COLUMN `user_id` TO `userId`;
+
+-- AlterTable
+ALTER TABLE `Profile`
+    MODIFY `userId` VARCHAR(36) NOT NULL,
+    MODIFY `uuid` VARCHAR(36) NOT NULL,
+    RENAME INDEX `Profile_user_id_key` TO `Profile_userId_key`;
+
+-- RenameForeignKey
+ALTER TABLE `Profile`
+    DROP FOREIGN KEY `Profile_user_id_fkey`,
+    ADD CONSTRAINT `Profile_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`uuid`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/nestjs-BE/server/prisma/schema.prisma
+++ b/nestjs-BE/server/prisma/schema.prisma
@@ -8,12 +8,17 @@ datasource db {
 }
 
 model User {
-  uuid     String      @id @db.VarChar(32)
-  email    String
-  provider String
-  profiles Profile[]
-  refresh_tokens RefreshToken[]
-  @@unique([email, provider])
+  uuid            String      @id @db.VarChar(36)
+  kakaoUser       KakaoUser?
+  profiles        Profile[]
+  refresh_tokens  RefreshToken[]
+}
+
+model KakaoUser {
+  id        Int     @id @default(autoincrement())
+  email     String  @unique
+  userUuid  String  @unique
+  user      User    @relation(fields: [userUuid], references: [uuid])
 }
 
 model RefreshToken {

--- a/nestjs-BE/server/prisma/schema.prisma
+++ b/nestjs-BE/server/prisma/schema.prisma
@@ -31,12 +31,12 @@ model RefreshToken {
 }
 
 model Profile {
-  uuid     String @id @db.VarChar(32)
-  user_id  String @unique @db.VarChar(32)
-  image    String
-  nickname String @db.VarChar(20)
-  user     User @relation(fields: [user_id], references: [uuid], onDelete: Cascade)
-  spaces   Profile_space[]
+  uuid      String  @id @db.VarChar(36)
+  userId    String  @unique @db.VarChar(36)
+  image     String
+  nickname  String  @db.VarChar(20)
+  user      User    @relation(fields: [userId], references: [uuid], onDelete: Cascade)
+  spaces    Profile_space[]
 }
 
 model Space {

--- a/nestjs-BE/server/src/auth/auth.controller.spec.ts
+++ b/nestjs-BE/server/src/auth/auth.controller.spec.ts
@@ -54,7 +54,7 @@ describe('AuthController', () => {
     usersService = module.get<UsersService>(UsersService);
   });
 
-  it('kakaoLogin user have been logged in', async () => {
+  it('kakaoLogin', async () => {
     const requestMock = { kakaoUserId: 0 };
     const kakaoUserAccountMock = { email: 'kakao email' };
     const tokenMock = {

--- a/nestjs-BE/server/src/auth/auth.controller.ts
+++ b/nestjs-BE/server/src/auth/auth.controller.ts
@@ -42,7 +42,7 @@ export class AuthController {
       kakaoUserDto.kakaoUserId,
     );
     if (!kakaoUserAccount) throw new NotFoundException();
-    const userData = { email: kakaoUserAccount.email, provider: 'kakao' };
+    const userData = { email: kakaoUserAccount.email };
     const user = await this.usersService.getOrCreateUser(userData);
     const profileData = {
       user_id: user.uuid,

--- a/nestjs-BE/server/src/profiles/profiles.service.ts
+++ b/nestjs-BE/server/src/profiles/profiles.service.ts
@@ -10,7 +10,7 @@ export class ProfilesService {
   constructor(private prisma: PrismaService) {}
 
   async findProfile(userUuid: string): Promise<Profile | null> {
-    return this.prisma.profile.findUnique({ where: { user_id: userUuid } });
+    return this.prisma.profile.findUnique({ where: { userId: userUuid } });
   }
 
   async findProfiles(profileUuids: string[]): Promise<Profile[]> {
@@ -21,11 +21,11 @@ export class ProfilesService {
 
   async getOrCreateProfile(data: CreateProfileDto): Promise<Profile> {
     return this.prisma.profile.upsert({
-      where: { user_id: data.user_id },
+      where: { userId: data.user_id },
       update: {},
       create: {
         uuid: generateUuid(),
-        user_id: data.user_id,
+        userId: data.user_id,
         image: data.image,
         nickname: data.nickname,
       },
@@ -38,7 +38,7 @@ export class ProfilesService {
   ): Promise<Profile | null> {
     try {
       return await this.prisma.profile.update({
-        where: { user_id: userUuid },
+        where: { userId: userUuid },
         data: { ...updateProfileDto },
       });
     } catch (err) {

--- a/nestjs-BE/server/src/users/dto/create-user.dto.ts
+++ b/nestjs-BE/server/src/users/dto/create-user.dto.ts
@@ -1,9 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
-
 export class CreateUserDto {
-  @ApiProperty({ example: 'test@gmail.com', description: 'email adress' })
   readonly email: string;
-
-  @ApiProperty({ example: 'kakao', description: 'social site name' })
-  readonly provider: string;
 }

--- a/nestjs-BE/server/src/users/users.service.ts
+++ b/nestjs-BE/server/src/users/users.service.ts
@@ -2,30 +2,37 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { User } from '@prisma/client';
-import generateUuid from '../utils/uuid';
+import { v4 as uuid } from 'uuid';
 
 @Injectable()
 export class UsersService {
   constructor(private prisma: PrismaService) {}
 
-  async findUserByEmailAndProvider(
-    email: string,
-    provider: string,
-  ): Promise<User | null> {
-    return this.prisma.user.findUnique({
-      where: { email_provider: { email, provider } },
-    });
-  }
-
   async getOrCreateUser(data: CreateUserDto): Promise<User> {
-    return this.prisma.user.upsert({
-      where: { email_provider: { email: data.email, provider: data.provider } },
-      update: {},
-      create: {
-        uuid: generateUuid(),
-        email: data.email,
-        provider: data.provider,
-      },
+    return this.prisma.$transaction(async () => {
+      const kakaoUser = await this.prisma.kakaoUser.findUnique({
+        where: { email: data.email },
+      });
+
+      if (!kakaoUser) {
+        const newUser = await this.prisma.user.create({
+          data: {
+            uuid: uuid(),
+          },
+        });
+        await this.prisma.kakaoUser.create({
+          data: {
+            email: data.email,
+            userUuid: newUser.uuid,
+          },
+        });
+        return newUser;
+      }
+
+      const user = await this.prisma.user.findUnique({
+        where: { uuid: kakaoUser.userUuid },
+      });
+      return user;
     });
   }
 }

--- a/nestjs-BE/server/test/auth.e2e-spec.ts
+++ b/nestjs-BE/server/test/auth.e2e-spec.ts
@@ -1,0 +1,67 @@
+import { HttpStatus, INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthModule } from '../src/auth/auth.module';
+import * as request from 'supertest';
+import { ConfigModule } from '@nestjs/config';
+
+describe('AuthController (e2e)', () => {
+  let app: INestApplication;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AuthModule, ConfigModule.forRoot({ isGlobal: true })],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    await app.init();
+  });
+
+  afterEach(async () => {
+    fetchSpy.mockRestore();
+
+    await app.close();
+  });
+
+  it('/auth/kakao-oauth (POST)', () => {
+    fetchSpy.mockResolvedValue({
+      json: async () => {
+        return { kakao_account: { email: 'test@email.com' } };
+      },
+      ok: true,
+    });
+
+    return request(app.getHttpServer())
+      .post('/auth/kakao-oauth')
+      .send({ kakaoUserId: 1 })
+      .expect(HttpStatus.CREATED)
+      .expect((res) => {
+        expect(res.body.statusCode).toBe(HttpStatus.OK);
+        expect(res.body.message).toBe('Success');
+        expect(res.body.data.access_token).toMatch(
+          /^[A-Za-z0-9-_]+?\.[A-Za-z0-9-_]+?\.[A-Za-z0-9-_]+$/,
+        );
+        expect(res.body.data.refresh_token).toMatch(
+          /^[A-Za-z0-9-_]+?\.[A-Za-z0-9-_]+?\.[A-Za-z0-9-_]+$/,
+        );
+      });
+  });
+
+  it('/auth/kakao-oauth (POST) received wrong kakao user id', () => {
+    fetchSpy.mockResolvedValue({
+      json: async () => null,
+      ok: false,
+    });
+
+    return request(app.getHttpServer())
+      .post('/auth/kakao-oauth')
+      .send({ kakaoUserId: 1 })
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({ statusCode: HttpStatus.NOT_FOUND, message: 'Not Found' });
+  });
+});


### PR DESCRIPTION
## 작업한 내용
- User 모델을 KakaoUser와 User모델로 분리. 기존 User의 kakao oauth와 관련된 부분을 분리해서 확장성을 높임.
- 테스트 추가